### PR TITLE
Bug  load profile rijswijk case #144

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "pyecore == 0.12.1",
         "pymoca >= 0.9.0",
         "rtc-tools == 2.6.0a3",
-        "pyesdl >= 23.12, < 24.0",
+        "pyesdl == 24.2",
         "pandas >= 1.3.1, < 2.0",
         "casadi == 3.6.3",
         "StrEnum == 0.4.15",

--- a/src/mesido/esdl/profile_parser.py
+++ b/src/mesido/esdl/profile_parser.py
@@ -290,7 +290,7 @@ class InfluxDBProfileReader(BaseProfileReader):
         time_series_data = InfluxDBProfileManager(conn_settings)
 
         time_series_data.load_influxdb(
-            '"' + profile.measurement + '"',
+            profile.measurement,
             [profile.field],
             profile.startDate,
             profile.endDate,


### PR DESCRIPTION
- Upgrade pyESDL and remove temp fix in profile parser which was required for the older pyESDL versions in the past
- There should be no bugs or temp fixes required for the examples/municipality/run_municipality.py -> the Rijswirk case
- Make sure you have the correct pyESDL version (24.2) installed locally as well