### PR TITLE
Write pump power profile data to influxDB

### DIFF
--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -934,8 +934,9 @@ class ScenarioOutput(TechnoEconomicMixin):
                     variables_one_hydraulic_system.append("PostProc.Velocity")
                     variables_two_hydraulic_system.append("PostProc.Velocity")
                     # Velocity at the pipe outlet [m/s]
-                    post_processed_velocity = results[
-                        f"{asset_name}.HeatOut.Q"] / parameters[f"{asset_name}.area"]
+                    post_processed_velocity = (
+                        results[f"{asset_name}.HeatOut.Q"] / parameters[f"{asset_name}.area"]
+                    )
 
                 profiles = ProfileManager()
                 profiles.profile_type = "DATETIME_LIST"

--- a/tests/models/heat_exchange/src/run_heat_exchanger.py
+++ b/tests/models/heat_exchange/src/run_heat_exchanger.py
@@ -3,6 +3,7 @@ from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.physics_mixin import PhysicsMixin
+from mesido.workflows.io.write_output import ScenarioOutput
 
 import numpy as np
 
@@ -67,6 +68,7 @@ class MinimizeSourcesHeatGoal(Goal):
 
 
 class HeatProblem(
+    ScenarioOutput,
     _GoalsAndOptions,
     PhysicsMixin,
     LinearizedOrderGoalProgrammingMixin,

--- a/tests/models/heatpump/src/run_heat_pump.py
+++ b/tests/models/heatpump/src/run_heat_pump.py
@@ -2,6 +2,7 @@ from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
+from mesido.workflows.io.write_output import ScenarioOutput
 
 import numpy as np
 
@@ -91,6 +92,7 @@ class MinimizeElectricityGoal(Goal):
 
 
 class HeatProblem(
+    ScenarioOutput,
     _GoalsAndOptions,
     PhysicsMixin,
     LinearizedOrderGoalProgrammingMixin,

--- a/tests/models/source_pipe_sink/src/double_pipe_heat.py
+++ b/tests/models/source_pipe_sink/src/double_pipe_heat.py
@@ -4,6 +4,8 @@ from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
+from mesido.workflows.io.write_output import ScenarioOutput
+
 
 from rtctools.optimization.collocated_integrated_optimization_problem import (
     CollocatedIntegratedOptimizationProblem,
@@ -44,6 +46,7 @@ class MinimizeProduction(Goal):
 
 
 class SourcePipeSink(
+    ScenarioOutput,
     TechnoEconomicMixin,
     LinearizedOrderGoalProgrammingMixin,
     SinglePassGoalProgrammingMixin,

--- a/tests/test_head_loss.py
+++ b/tests/test_head_loss.py
@@ -46,6 +46,11 @@ class TestHeadLoss(TestCase):
         ]:
             # Added for case where head loss is modelled via DW
             class SourcePipeSinkDW(SourcePipeSink):
+                # Do not delete: this is used to manualy check writing out of profile data
+                # def post(self):
+                #     super().post()
+                #     self._write_updated_esdl(self.get_energy_system_copy(), optimizer_sim=True)
+
                 def energy_system_options(self):
                     options = super().energy_system_options()
 
@@ -70,6 +75,17 @@ class TestHeadLoss(TestCase):
 
                     return options
 
+            # Do not delete kwargs: this is used to manualy check writing out of profile data
+            kwargs = {
+                "write_result_db_profiles": False,
+                "influxdb_host": "localhost",
+                "influxdb_port": 8086,
+                "influxdb_username": None,
+                "influxdb_password": None,
+                "influxdb_ssl": False,
+                "influxdb_verify_ssl": False,
+            }
+
             solution = run_optimization_problem(
                 SourcePipeSinkDW,
                 base_folder=base_folder,
@@ -77,6 +93,7 @@ class TestHeadLoss(TestCase):
                 esdl_parser=ESDLFileParser,
                 profile_reader=ProfileReaderFromFile,
                 input_timeseries_file="timeseries_import.csv",
+                **kwargs,
             )
             results = solution.extract_results()
 

--- a/tests/test_head_loss.py
+++ b/tests/test_head_loss.py
@@ -77,7 +77,7 @@ class TestHeadLoss(TestCase):
 
             # Do not delete kwargs: this is used to manualy check writing out of profile data
             kwargs = {
-                "write_result_db_profiles": False,
+                "write_result_db_profiles": True,
                 "influxdb_host": "localhost",
                 "influxdb_port": 8086,
                 "influxdb_username": None,

--- a/tests/test_multiple_in_and_out_port_components.py
+++ b/tests/test_multiple_in_and_out_port_components.py
@@ -33,14 +33,39 @@ class TestHEX(TestCase):
         )
 
         base_folder = Path(run_heat_exchanger.__file__).resolve().parent.parent
+        # -----------------------------------------------------------------------------------------
+        # Do not delete: this is used to manualy check writing out of profile data
+
+        class HeatProblemPost(HeatProblem):
+            # def post(self):
+            #     super().post()
+            #     self._write_updated_esdl(self.get_energy_system_copy(), optimizer_sim=True)
+
+            def energy_system_options(self):
+                options = super().energy_system_options()
+                # self.heat_network_settings["minimize_head_losses"] = True  # used for manual tests
+                return options
+
+        # Do not delete kwargs: this is used to manualy check writing out of profile data
+        kwargs = {
+            "write_result_db_profiles": False,
+            "influxdb_host": "localhost",
+            "influxdb_port": 8086,
+            "influxdb_username": None,
+            "influxdb_password": None,
+            "influxdb_ssl": False,
+            "influxdb_verify_ssl": False,
+        }
+        # -----------------------------------------------------------------------------------------
 
         solution = run_optimization_problem(
-            HeatProblem,
+            HeatProblemPost,
             base_folder=base_folder,
             esdl_file_name="heat_exchanger.esdl",
             esdl_parser=ESDLFileParser,
             profile_reader=ProfileReaderFromFile,
             input_timeseries_file="timeseries_import.xml",
+            **kwargs,
         )
 
         results = solution.extract_results()
@@ -99,13 +124,39 @@ class TestHP(TestCase):
 
         base_folder = Path(run_heat_pump.__file__).resolve().parent.parent
 
+        # -----------------------------------------------------------------------------------------
+        # Do not delete: this is used to manualy check writing out of profile data
+
+        class HeatProblemPost(HeatProblem):
+            # def post(self):
+            #     super().post()
+            #     self._write_updated_esdl(self.get_energy_system_copy(), optimizer_sim=True)
+
+            def energy_system_options(self):
+                options = super().energy_system_options()
+                # self.heat_network_settings["minimize_head_losses"] = True  # used for manual tests
+                return options
+
+        # Do not delete kwargs: this is used to manualy check writing out of profile data
+        kwargs = {
+            "write_result_db_profiles": False,
+            "influxdb_host": "localhost",
+            "influxdb_port": 8086,
+            "influxdb_username": None,
+            "influxdb_password": None,
+            "influxdb_ssl": False,
+            "influxdb_verify_ssl": False,
+        }
+        # -----------------------------------------------------------------------------------------
+
         solution = run_optimization_problem(
-            HeatProblem,
+            HeatProblemPost,
             base_folder=base_folder,
             esdl_file_name="heat_pump.esdl",
             esdl_parser=ESDLFileParser,
             profile_reader=ProfileReaderFromFile,
             input_timeseries_file="timeseries_import.xml",
+            **kwargs,
         )
 
         results = solution.extract_results()


### PR DESCRIPTION
- Added pump power for assets: heat_source, heat_buffer, ates and pump, heat_exchanger & heat_pump
- Only head and/or pump power when head_loss_min is active
- Added velocity in pipe

Notes: 
This still needs to be tested in the PoC or complete test environment with inflxuDB to see if profiles display correctly