### PR TITLE
70 time zone setting

### DIFF
--- a/src/mesido/esdl/profile_parser.py
+++ b/src/mesido/esdl/profile_parser.py
@@ -303,7 +303,15 @@ class InfluxDBProfileReader(BaseProfileReader):
                     "profile for each asset"
                 )
 
-        index = pd.DatetimeIndex(data=[x[0] for x in time_series_data.profile_data_list])
+        if not time_series_data.profile_data_list[0][0].tzinfo:
+            index = pd.DatetimeIndex(
+                data=[x[0] for x in time_series_data.profile_data_list],
+                tz=datetime.timezone.utc,
+            )
+            logger.warning("No timezone specified for the input profile: default UTC has been used")
+        else:
+            index = pd.DatetimeIndex(data=[x[0] for x in time_series_data.profile_data_list])
+
         data = [x[1] for x in time_series_data.profile_data_list]
         series = pd.Series(data=data, index=index)
         self._df[profile.id] = series
@@ -440,25 +448,34 @@ class ProfileReaderFromFile(BaseProfileReader):
         data = pd.read_csv(self._file_path)
         try:
             timeseries_import_times = [
-                datetime.datetime.strptime(entry.replace("Z", ""), "%Y-%m-%d %H:%M:%S")
+                datetime.datetime.strptime(entry.replace("Z", ""), "%Y-%m-%d %H:%M:%S").replace(
+                    tzinfo=datetime.timezone.utc
+                )
                 for entry in data["DateTime"].to_numpy()
             ]
         except ValueError:
             try:
                 timeseries_import_times = [
-                    datetime.datetime.strptime(entry.replace("Z", ""), "%Y-%m-%dT%H:%M:%S")
+                    datetime.datetime.strptime(entry.replace("Z", ""), "%Y-%m-%dT%H:%M:%S").replace(
+                        tzinfo=datetime.timezone.utc
+                    )
                     for entry in data["DateTime"].to_numpy()
                 ]
             except ValueError:
                 try:
                     timeseries_import_times = [
-                        datetime.datetime.strptime(entry.replace("Z", ""), "%d-%m-%Y %H:%M")
+                        datetime.datetime.strptime(
+                            entry.replace("Z", ""), "%d-%m-%Y %H:%M"
+                        ).replace(tzinfo=datetime.timezone.utc)
                         for entry in data["DateTime"].to_numpy()
                     ]
                 except ValueError:
                     raise _ProfileParserException("Date time string is not in a supported format")
 
+        logger.warning("Timezone specification not supported yet: default UTC has been used")
+
         self._reference_datetimes = timeseries_import_times
+
         for ensemble_member in range(ensemble_size):
             for component_type, var_name in self.component_type_to_var_name_map.items():
                 for component_name in energy_system_components.get(component_type, []):
@@ -499,6 +516,11 @@ class ProfileReaderFromFile(BaseProfileReader):
             )
 
         # Convert timeseries timestamps to seconds since t0 for internal use
+        if not data.times[0].tzinfo:
+            for ii in range(len(data.times)):
+                data.times[ii] = data.times[ii].replace(tzinfo=datetime.timezone.utc)
+            logger.warning("No timezone specified for the input profile: default UTC has been used")
+
         self._reference_datetimes = data.times
 
         # Offer input timeseries to IOMixin

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import numbers
@@ -22,7 +23,6 @@ import numpy as np
 
 import pandas as pd
 
-import pytz
 
 from rtctools.optimization.timeseries import Timeseries
 
@@ -966,7 +966,7 @@ class ScenarioOutput(TechnoEconomicMixin):
 
                     for ii in range(len(self.times())):
                         if not self.io.datetimes[ii].tzinfo:
-                            data_row = [pytz.utc.localize(self.io.datetimes[ii])]
+                            data_row = [self.io.datetimes[ii].replace(tzinfo=datetime.timezone.utc)]
                         else:
                             data_row = [self.io.datetimes[ii]]
 
@@ -998,11 +998,19 @@ class ScenarioOutput(TechnoEconomicMixin):
                                 profiles.profile_header.append(variable)
                                 # Set profile database attributes for the esdl asset
                                 if not self.io.datetimes[0].tzinfo:
-                                    start_date_time = pytz.utc.localize(self.io.datetimes[0])
+                                    start_date_time = self.io.datetimes[0].replace(
+                                        tzinfo=datetime.timezone.utc
+                                    )
+                                    logger.warning(
+                                        "No timezone specified for the output profile: default UTC"
+                                        f"has been used for asset {asset_name} variable {variable}"
+                                    )
                                 else:
                                     start_date_time = self.io.datetimes[0]
                                 if not self.io.datetimes[-1].tzinfo:
-                                    end_date_time = pytz.utc.localize(self.io.datetimes[-1])
+                                    end_date_time = self.io.datetimes[-1].replace(
+                                        tzinfo=datetime.timezone.utc
+                                    )
                                 else:
                                     end_date_time = self.io.datetimes[-1]
 

--- a/tests/test_esdl_pycml.py
+++ b/tests/test_esdl_pycml.py
@@ -56,3 +56,12 @@ class TestESDL(TestCase):
     #     np.testing.assert_allclose(
     #         case_python._objective_values[0], case_esdl._objective_values, rtol=1e-5, atol=1e-5
     #     )
+
+
+if __name__ == "__main__":
+    import time
+
+    start_time = time.time()
+    a = TestESDL()
+    a.test_basic_source_and_demand_heat()
+    temp = 0

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -157,7 +157,7 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
-        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
+        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, True or datetime.timezone.utc)
 
         expected_array = np.array([1.0e8] * 3)
         np.testing.assert_equal(

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from pathlib import Path
 from typing import Optional
@@ -7,7 +8,6 @@ import esdl
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import InfluxDBProfileReader, ProfileReaderFromFile
 from mesido.workflows import EndScenarioSizingStagedHIGHS
-
 
 import numpy as np
 
@@ -33,6 +33,9 @@ class TestProfileLoading(unittest.TestCase):
         EndScenarioSizing is called thus the checks done are on profile lenghts
         and some values. This is because this scenario should also do aggragation
         of the profiles for non-peak days.
+
+        Also check:
+            - that the timezone setting from the "influx_mock.csv" is correct
         """
         import models.unit_cases.case_1a.src.run_1a as run_1a
 
@@ -50,6 +53,8 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
+        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
+
         # the three demands in the test ESDL
         for demand_name in ["HeatingDemand_2ab9", "HeatingDemand_6662", "HeatingDemand_506c"]:
             profile_values = problem.get_timeseries(f"{demand_name}.target_heat_demand").values
@@ -63,7 +68,8 @@ class TestProfileLoading(unittest.TestCase):
     def test_loading_from_csv(self):
         """
         This test constructs a problem with input profiles read from a CSV file.
-        The test checks if the profiles read match the profiles from the CVS file.
+        The test checks if the profiles read match the profiles from the CVS file and that the
+        default UTC timezone has been set.
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
         from models.unit_cases_electricity.electrolyzer.src.example import MILPProblem
@@ -82,6 +88,8 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
+        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
+
         expected_array = np.array([1.0e8] * 3)
         np.testing.assert_equal(
             expected_array,
@@ -97,7 +105,8 @@ class TestProfileLoading(unittest.TestCase):
     def test_loading_from_xml(self):
         """
         This test loads a simple problem using an XML file for input profiles.
-        The test checks if the load profiles match those specified in the XML file.
+        The test checks if the load profiles match those specified in the XML file and that the
+        default UTC timezone has been set.
         """
         import models.basic_source_and_demand.src.heat_comparison as heat_comparison
         from models.basic_source_and_demand.src.heat_comparison import HeatESDL
@@ -115,6 +124,8 @@ class TestProfileLoading(unittest.TestCase):
             input_timeseries_file="timeseries.xml",
         )
         problem.pre()
+
+        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
 
         expected_array = np.array([1.5e5] * 16 + [1.0e5] * 13 + [0.5e5] * 16)
         np.testing.assert_equal(
@@ -145,6 +156,8 @@ class TestProfileLoading(unittest.TestCase):
             input_timeseries_file="timeseries.csv",
         )
         problem.pre()
+
+        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
 
         expected_array = np.array([1.0e8] * 3)
         np.testing.assert_equal(

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -13,6 +13,8 @@ import numpy as np
 
 import pandas as pd
 
+import pytz
+
 
 class MockInfluxDBProfileReader(InfluxDBProfileReader):
     def __init__(self, energy_system: esdl.EnergySystem, file_path: Optional[Path]):
@@ -53,10 +55,10 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
-        if not problem.io.reference_datetime.tzinfo:
-            ...
-        else:
-            np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
+        # The timezone setting is dependand on what is specificied
+        np.testing.assert_equal(
+            problem.io.reference_datetime.tzinfo, pytz.timezone("UTC") or datetime.timezone.utc
+        )
 
         # the three demands in the test ESDL
         for demand_name in ["HeatingDemand_2ab9", "HeatingDemand_6662", "HeatingDemand_506c"]:

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -54,7 +54,7 @@ class TestProfileLoading(unittest.TestCase):
         problem.pre()
 
         if not problem.io.reference_datetime.tzinfo:
-            exit("error")
+            ...
         else:
             np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
 

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -157,7 +157,10 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
-        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, True or datetime.timezone.utc)
+        if not problem.io.reference_datetime.tzinfo:
+            ...
+        else:
+            np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
 
         expected_array = np.array([1.0e8] * 3)
         np.testing.assert_equal(

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -53,7 +53,10 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
-        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
+        if not problem.io.reference_datetime.tzinfo:
+            exit("error")
+        else:
+            np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
 
         # the three demands in the test ESDL
         for demand_name in ["HeatingDemand_2ab9", "HeatingDemand_6662", "HeatingDemand_506c"]:
@@ -157,10 +160,7 @@ class TestProfileLoading(unittest.TestCase):
         )
         problem.pre()
 
-        if not problem.io.reference_datetime.tzinfo:
-            ...
-        else:
-            np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
+        np.testing.assert_equal(problem.io.reference_datetime.tzinfo, datetime.timezone.utc)
 
         expected_array = np.array([1.0e8] * 3)
         np.testing.assert_equal(


### PR DESCRIPTION
- Set timezone setting to UTC (if no timezone was specified) when a profile is read from csv, xml or influx
- Standardized timezone by getting rid of pytz and use datetime everywhere when timezone settings are updated. Still exists in the test case due to the specific input setting