### PR TITLE
Error not matching demand

### DIFF
--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -320,7 +320,7 @@ class EndScenarioSizing(
                 self.solver_stats,
             )
         )
-        if priority == 1 and self.objective_value>0:
+        if priority == 1 and self.objective_value>1e-12:
             raise RuntimeError("The heating demand is not matched")
 
 

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -75,6 +75,7 @@ class SolverHIGHS:
         options["casadi_solver"] = self._qpsol
         options["solver"] = "highs"
         highs_options = options["highs"] = {}
+        # highs_options["time_limit"] = 100
         if hasattr(self, "_stage"):
             if self._stage == 1:
                 highs_options["mip_rel_gap"] = 0.005
@@ -294,6 +295,7 @@ class EndScenarioSizing(
 
         super().priority_started(priority)
 
+
     def priority_completed(self, priority):
         super().priority_completed(priority)
 
@@ -309,6 +311,9 @@ class EndScenarioSizing(
                 self.solver_stats,
             )
         )
+        if priority == 1 and self.objective_value>1e-12:
+            raise RuntimeError("The heating demand is not matched")
+
 
     def post(self):
         # In case the solver fails, we do not get in priority_completed(). We

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -75,7 +75,6 @@ class SolverHIGHS:
         options["casadi_solver"] = self._qpsol
         options["solver"] = "highs"
         highs_options = options["highs"] = {}
-        # highs_options["time_limit"] = 100
         if hasattr(self, "_stage"):
             if self._stage == 1:
                 highs_options["mip_rel_gap"] = 0.005
@@ -267,6 +266,16 @@ class EndScenarioSizing(
             self.state_vector(canonical, ensemble_member) * self.variable_nominal(canonical) * sign
         )
 
+    def solver_options(self):
+        options = super().solver_options()
+        if options["solver"] == "highs":
+            highs_options = options["highs"]
+            if self.__priority == 1:
+                highs_options["time_limit"] = 100
+            else:
+                highs_options["time_limit"] = 100000
+        return options
+
     def solver_success(self, solver_stats, log_solver_failure_as_error):
         success, log_level = super().solver_success(solver_stats, log_solver_failure_as_error)
 
@@ -311,7 +320,7 @@ class EndScenarioSizing(
                 self.solver_stats,
             )
         )
-        if priority == 1 and self.objective_value>1e-12:
+        if priority == 1 and self.objective_value>0:
             raise RuntimeError("The heating demand is not matched")
 
 

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -304,7 +304,6 @@ class EndScenarioSizing(
 
         super().priority_started(priority)
 
-
     def priority_completed(self, priority):
         super().priority_completed(priority)
 
@@ -320,9 +319,8 @@ class EndScenarioSizing(
                 self.solver_stats,
             )
         )
-        if priority == 1 and self.objective_value>1e-12:
+        if priority == 1 and self.objective_value > 1e-12:
             raise RuntimeError("The heating demand is not matched")
-
 
     def post(self):
         # In case the solver fails, we do not get in priority_completed(). We

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -319,7 +319,7 @@ class EndScenarioSizing(
                 self.solver_stats,
             )
         )
-        if priority == 1 and self.objective_value > 1e-12:
+        if priority == 1 and self.objective_value > 1e-6:
             raise RuntimeError("The heating demand is not matched")
 
     def post(self):


### PR DESCRIPTION
In case heat demand is not matched we want to terminate the optimisation and provide feedback to the user.
Furthermore in normal cases 100s for goal 1 (demand matching) should be sufficient thus otherwise this time constraint can be used to terminate the optimisation.