### PR TITLE
53 investigating where other time is lost before starting goal programming

### DIFF
--- a/examples/PoCTutorial/model/PoC Tutorial.esdl
+++ b/examples/PoCTutorial/model/PoC Tutorial.esdl
@@ -318,7 +318,7 @@
         <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_08fd" id="08fd3385-681a-4211-a083-51775cc99daa" power="15000000.0">
           <geometry xsi:type="esdl:Point" lon="4.373245239257813" lat="51.99648151568376" CRS="WGS84"/>
           <port xsi:type="esdl:InPort" connectedTo="787c6ae3-96da-41e1-af86-6e68a1e28cb1" id="01caa60f-1549-4f3f-817e-e4e6807b2398" carrier="9f6aeb1a-138b-4bb9-9a09-d524e94658e6" name="In">
-            <profile xsi:type="esdl:InfluxDBProfile" multiplier="2.0" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="ddd73fb0-d96f-4127-8d39-869455c77930" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand4_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
+            <profile xsi:type="esdl:InfluxDBProfile" multiplier="0.5" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="ddd73fb0-d96f-4127-8d39-869455c77930" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand1_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
               <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
             </profile>
           </port>

--- a/examples/PoCTutorial/model/PoC Tutorial.esdl
+++ b/examples/PoCTutorial/model/PoC Tutorial.esdl
@@ -287,7 +287,7 @@
         <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_b0ff" id="b0ff0df6-4a47-43a5-a0a5-aa10975c0a5c" power="15000000.0">
           <geometry xsi:type="esdl:Point" lon="4.373545646667481" lat="52.00105253065436" CRS="WGS84"/>
           <port xsi:type="esdl:InPort" connectedTo="5169316d-ae93-4f04-9a34-7c776444b651" id="2c5a109b-0d98-47b6-acc1-05e1708f8b85" carrier="9f6aeb1a-138b-4bb9-9a09-d524e94658e6" name="In">
-            <profile xsi:type="esdl:InfluxDBProfile" multiplier="1.0" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="b8150ac7-ea23-4be6-b5a3-b6974b8df58d" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand4_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
+            <profile xsi:type="esdl:InfluxDBProfile" multiplier="0.75" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="b8150ac7-ea23-4be6-b5a3-b6974b8df58d" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand4_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
               <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
             </profile>
           </port>
@@ -347,7 +347,7 @@
         <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_8fbe" id="8fbe3d4e-5d5b-4489-9271-9969c2b9e589" power="15000000.0">
           <geometry xsi:type="esdl:Point" lon="4.379038810729981" lat="51.99069441691871" CRS="WGS84"/>
           <port xsi:type="esdl:InPort" connectedTo="13edd58c-4a04-4770-8aac-c6e8689acbba" id="23cdb929-5cfc-4b8d-963e-06b6e6cf3a5c" carrier="9f6aeb1a-138b-4bb9-9a09-d524e94658e6" name="In">
-            <profile xsi:type="esdl:InfluxDBProfile" multiplier="1.0" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="5ae97047-619a-4119-84f3-848b36743e5d" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand3_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
+            <profile xsi:type="esdl:InfluxDBProfile" multiplier="0.3" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="5ae97047-619a-4119-84f3-848b36743e5d" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand5_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
               <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
             </profile>
           </port>

--- a/examples/PoCTutorial/model/PoC Tutorial.esdl
+++ b/examples/PoCTutorial/model/PoC Tutorial.esdl
@@ -318,7 +318,7 @@
         <asset xsi:type="esdl:HeatingDemand" name="HeatingDemand_08fd" id="08fd3385-681a-4211-a083-51775cc99daa" power="15000000.0">
           <geometry xsi:type="esdl:Point" lon="4.373245239257813" lat="51.99648151568376" CRS="WGS84"/>
           <port xsi:type="esdl:InPort" connectedTo="787c6ae3-96da-41e1-af86-6e68a1e28cb1" id="01caa60f-1549-4f3f-817e-e4e6807b2398" carrier="9f6aeb1a-138b-4bb9-9a09-d524e94658e6" name="In">
-            <profile xsi:type="esdl:InfluxDBProfile" multiplier="0.5" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="ddd73fb0-d96f-4127-8d39-869455c77930" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand1_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
+            <profile xsi:type="esdl:InfluxDBProfile" multiplier="0.5" startDate="2018-12-31T23:00:00.000000+0000" filters="" id="ddd73fb0-d96f-4127-8d39-869455c77930" database="energy_profiles" measurement="WarmingUp default profiles" host="profiles.warmingup.info" field="demand4_MW" port="443" endDate="2019-12-31T22:00:00.000000+0000">
               <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
             </profile>
           </port>

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -491,6 +491,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                             pipe_class_cost_ordering_name
                         ] = (0.0, 1.0)
 
+        set_self_hot_pipes = set(self.hot_pipes)
         for pipe in self.energy_system_components.get("heat_pipe", []):
             pipe_classes = self.pipe_classes(pipe)
             # cold_pipe = self.hot_to_cold_pipe(pipe)
@@ -679,7 +680,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
 
                 for c in pipe_classes:
                     neighbour = self.has_related_pipe(pipe)
-                    if neighbour and pipe not in self.hot_pipes:
+                    if neighbour and pipe not in set_self_hot_pipes:
                         cold_pipe = self.cold_to_hot_pipe(pipe)
                         pipe_class_var_name = f"{cold_pipe}__hn_pipe_class_{c.name}"
                         pipe_class_ordering_name = (
@@ -1282,6 +1283,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
         unique_pipe_classes = self.get_unique_pipe_classes()
         pipe_class_count_sum = {pc.name: 0 for pc in unique_pipe_classes}
 
+        set_self_hot_pipes = set(self.hot_pipes)
         for p in self.energy_system_components.get("heat_pipe", []):
             try:
                 pipe_classes = self._heat_pipe_topo_pipe_class_map[p]
@@ -1290,7 +1292,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
             else:
                 for pc in pipe_classes:
                     neighbour = self.has_related_pipe(p)
-                    if neighbour and p not in self.hot_pipes:
+                    if neighbour and p not in set_self_hot_pipes:
                         var_name = f"{self.cold_to_hot_pipe(p)}__hn_pipe_class_{pc.name}"
                     else:
                         var_name = f"{p}__hn_pipe_class_{pc.name}"
@@ -1373,7 +1375,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                 pipe,
                 pipe_classes,
             ) in self.__heat_pipe_topo_pipe_class_heat_loss_ordering_map.items():
-                if pipe in self.hot_pipes and self.has_related_pipe(pipe):
+                if pipe in set_self_hot_pipes and self.has_related_pipe(pipe):
                     heat_loss_sym_name = self._pipe_heat_loss_map[pipe]
                     heat_loss_sym = self.extra_variable(heat_loss_sym_name, ensemble_member)
                     cold_name = self._pipe_heat_loss_map[self.hot_to_cold_pipe(pipe)]
@@ -1385,7 +1387,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                             self._pipe_heat_losses[self.hot_to_cold_pipe(pipe)],
                         )
                     ]
-                elif pipe in self.hot_pipes and not self.has_related_pipe(pipe):
+                elif pipe in set_self_hot_pipes and not self.has_related_pipe(pipe):
                     heat_loss_sym_name = self._pipe_heat_loss_map[pipe]
                     heat_loss_sym = self.extra_variable(heat_loss_sym_name, ensemble_member)
 

--- a/src/mesido/esdl/profile_parser.py
+++ b/src/mesido/esdl/profile_parser.py
@@ -196,17 +196,48 @@ class InfluxDBProfileReader(BaseProfileReader):
         profiles: Dict[str, np.ndarray] = dict()
         logger.info("Reading profiles from InfluxDB")
         self._reference_datetimes = None
+
+        # Get list of unique profiles and associated series based on specific profile attributes
+        unique_profiles = []
+        unique_profiles_attributes = []  # a list containning lists of attributes
+        unique_series = []
         for profile in [
             x for x in self._energy_system.eAllContents() if isinstance(x, esdl.InfluxDBProfile)
         ]:
-            series = self._load_profile_timeseries_from_database(profile=profile)
-            self._check_profile_time_series(profile_time_series=series, profile=profile)
+            if [
+                profile.database,
+                profile.field,
+                profile.host,
+                profile.startDate,
+                profile.endDate,
+                profile.measurement,
+                profile.port,
+            ] not in unique_profiles_attributes:
+                unique_profiles_attributes.append(
+                    [
+                        profile.database,
+                        profile.field,
+                        profile.host,
+                        profile.startDate,
+                        profile.endDate,
+                        profile.measurement,
+                        profile.port,
+                    ]
+                )
+                unique_profiles.append(profile)
+
+            unique_series.append(
+                self._load_profile_timeseries_from_database(profile=unique_profiles[-1])
+            )
+            self._check_profile_time_series(
+                profile_time_series=unique_series[-1], profile=unique_profiles[-1]
+            )
             if self._reference_datetimes is None:
                 # TODO: since the previous function ensures it's a date time index, I'm not sure
                 #  how to get rid of this type checking warning
-                self._reference_datetimes = series.index
+                self._reference_datetimes = unique_series[-1].index
             else:
-                if not all(series.index == self._reference_datetimes):
+                if not all(unique_series[-1].index == self._reference_datetimes):
                     raise RuntimeError(
                         f"Obtained a profile for asset {profile.field} with a "
                         f"timeseries index that doesn't match the timeseries of "
@@ -214,6 +245,25 @@ class InfluxDBProfileReader(BaseProfileReader):
                         f"specified to be loaded for each asset covers exactly the "
                         f"same timeseries. "
                     )
+        # Loop trough all the requried profiles in the energy system and assign the profile data:
+        # - series: use the unique series data, without reading from the database again
+        # - other profile info: get it from the specific profile
+        for profile in [
+            x for x in self._energy_system.eAllContents() if isinstance(x, esdl.InfluxDBProfile)
+        ]:
+            index_of_unique_profile = unique_profiles_attributes.index(
+                [
+                    profile.database,
+                    profile.field,
+                    profile.host,
+                    profile.startDate,
+                    profile.endDate,
+                    profile.measurement,
+                    profile.port,
+                ]
+            )
+            series = unique_series[index_of_unique_profile]
+            self._check_profile_time_series(profile_time_series=series, profile=profile)
             converted_dataframe = self._convert_profile_to_correct_unit(
                 profile_time_series=series, profile=profile
             )

--- a/src/mesido/esdl/profile_parser.py
+++ b/src/mesido/esdl/profile_parser.py
@@ -226,25 +226,25 @@ class InfluxDBProfileReader(BaseProfileReader):
                 )
                 unique_profiles.append(profile)
 
-            unique_series.append(
-                self._load_profile_timeseries_from_database(profile=unique_profiles[-1])
-            )
-            self._check_profile_time_series(
-                profile_time_series=unique_series[-1], profile=unique_profiles[-1]
-            )
-            if self._reference_datetimes is None:
-                # TODO: since the previous function ensures it's a date time index, I'm not sure
-                #  how to get rid of this type checking warning
-                self._reference_datetimes = unique_series[-1].index
-            else:
-                if not all(unique_series[-1].index == self._reference_datetimes):
-                    raise RuntimeError(
-                        f"Obtained a profile for asset {profile.field} with a "
-                        f"timeseries index that doesn't match the timeseries of "
-                        f"other assets. Please ensure that the profile that is "
-                        f"specified to be loaded for each asset covers exactly the "
-                        f"same timeseries. "
-                    )
+                unique_series.append(
+                    self._load_profile_timeseries_from_database(profile=unique_profiles[-1])
+                )
+                self._check_profile_time_series(
+                    profile_time_series=unique_series[-1], profile=unique_profiles[-1]
+                )
+                if self._reference_datetimes is None:
+                    # TODO: since the previous function ensures it's a date time index, I'm not sure
+                    #  how to get rid of this type checking warning
+                    self._reference_datetimes = unique_series[-1].index
+                else:
+                    if not all(unique_series[-1].index == self._reference_datetimes):
+                        raise RuntimeError(
+                            f"Obtained a profile for asset {profile.field} with a "
+                            f"timeseries index that doesn't match the timeseries of "
+                            f"other assets. Please ensure that the profile that is "
+                            f"specified to be loaded for each asset covers exactly the "
+                            f"same timeseries. "
+                        )
         # Loop trough all the requried profiles in the energy system and assign the profile data:
         # - series: use the unique series data, without reading from the database again
         # - other profile info: get it from the specific profile

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -245,6 +245,10 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
 
         bounds = self.bounds()
 
+        # Set structure used instead of list. Purpose: to make lookup faster when there are many
+        # pipes in the network.
+        set_self_hot_pipes = set(self.hot_pipes)
+
         for pipe_name in self.energy_system_components.get("heat_pipe", []):
             head_loss_var = f"{pipe_name}.__head_loss"
             initialized_vars = self._hn_head_loss_class.initialize_variables_nominals_and_bounds(
@@ -290,7 +294,7 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                     ] = initialized_vars[10][pipe_linear_line_segment_var_name]
 
             neighbour = self.has_related_pipe(pipe_name)
-            if neighbour and pipe_name not in self.hot_pipes:
+            if neighbour and pipe_name not in set_self_hot_pipes:
                 flow_dir_var = f"{self.cold_to_hot_pipe(pipe_name)}__flow_direct_var"
             else:
                 flow_dir_var = f"{pipe_name}__flow_direct_var"
@@ -320,7 +324,7 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
 
             if parameters[f"{pipe_name}.disconnectable"]:
                 neighbour = self.has_related_pipe(pipe_name)
-                if neighbour and pipe_name not in self.hot_pipes:
+                if neighbour and pipe_name not in set_self_hot_pipes:
                     disconnected_var = f"{self.cold_to_hot_pipe(pipe_name)}__is_disconnected"
                 else:
                     disconnected_var = f"{pipe_name}__is_disconnected"

--- a/tests/test_updated_esdl_pre_process.py
+++ b/tests/test_updated_esdl_pre_process.py
@@ -19,6 +19,7 @@ class TestUpdatedESDL(TestCase):
         Additional checks:
          - Check that the unique profile identification in profile_parser assigns the correct
          profile
+         - Check that the correct mulitpler value has been used
 
         """
 
@@ -52,28 +53,46 @@ class TestUpdatedESDL(TestCase):
         # demand profiles are the adapted profiles (peak-hourly, rest-5daily). Therefore the
         # expected max and average hard-coded values are compared to the problem values.
         np.testing.assert_allclose(
-            1201200.0,  # demand4_MW, multiplier 0.75
+            1207800,
             max(problem.get_timeseries("HeatingDemand_b0ff.target_heat_demand").values),
+            # demand4_MW, multiplier 0.75, same demand profile as demand HeatingDemand_08fd, but
+            # with a different multiplier. So one would expect that this value differs from
+            # HeatingDemand_08fd
         )
         np.testing.assert_allclose(
-            720720.0,  # demand5_MW, multiplier 0.3
+            724680.0,  # demand5_MW, multiplier 0.3
             max(problem.get_timeseries("HeatingDemand_8fbe.target_heat_demand").values),
         )
         np.testing.assert_allclose(
-            916316.712,  # demand1_MW, multiplier 0.5
+            805200.0,  # demand4_MW, multiplier 0.5
             max(problem.get_timeseries("HeatingDemand_08fd.target_heat_demand").values),
         )
         np.testing.assert_allclose(
-            443413.79,  # demand4_MW, multiplier 0.75
+            469709.62,  # demand4_MW, multiplier 0.75
             np.average(problem.get_timeseries("HeatingDemand_b0ff.target_heat_demand").values),
         )
         np.testing.assert_allclose(
-            266048.27,  # demand5_MW, multiplier 0.3
+            281825.77,  # demand5_MW, multiplier 0.3
             np.average(problem.get_timeseries("HeatingDemand_8fbe.target_heat_demand").values),
         )
         np.testing.assert_allclose(
-            575570.74,  # demand1_MW, multiplier 0.5
+            313139.75,  # demand4_MW, multiplier 0.5
             np.average(problem.get_timeseries("HeatingDemand_08fd.target_heat_demand").values),
+        )
+
+        # Checkk that the correct multiplier value was used
+        # Compare 2 max values where the same profile was used but with different multiplier values
+        # HeatingDemand_08fd: multiplier 0.5
+        # HeatingDemand_b0ff: multplier 0.75
+        np.testing.assert_allclose(
+            max(problem.get_timeseries("HeatingDemand_08fd.target_heat_demand").values) / 0.5,
+            max(problem.get_timeseries("HeatingDemand_b0ff.target_heat_demand").values) / 0.75,
+        )
+        np.testing.assert_allclose(
+            np.average(problem.get_timeseries("HeatingDemand_08fd.target_heat_demand").values)
+            / 0.5,
+            np.average(problem.get_timeseries("HeatingDemand_b0ff.target_heat_demand").values)
+            / 0.75,
         )
 
 

--- a/tests/test_updated_esdl_pre_process.py
+++ b/tests/test_updated_esdl_pre_process.py
@@ -5,15 +5,20 @@ from unittest import TestCase
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.workflows import run_end_scenario_sizing
 
+import numpy as np
+
 
 class TestUpdatedESDL(TestCase):
-
     def test_updated_esdl(self):
         """
         Check that the updated ESDL resulting from optmizing a network, is correct by using the
         PoCTutorial and the Grow_workflow. This is done for the actual esdl file and the esdl
         string created by MESIDO. Both these resulting optimized energy systems should be identical
         and it is only the MESIDO esdl saving method that differs.
+
+        Additional checks:
+         - Check that the unique profile identification in profile_parser assigns the correct
+         profile
 
         """
 
@@ -41,6 +46,35 @@ class TestUpdatedESDL(TestCase):
         )
         file.write(optimized_esdl_string)
         file.close()
+
+        # Check the unique profile identification in profile_parser
+        # Test that the correct demand profile is assigned to a demand as expected. Note that the
+        # demand profiles are the adapted profiles (peak-hourly, rest-5daily). Therefore the
+        # expected max and average hard-coded values are compared to the problem values.
+        np.testing.assert_allclose(
+            1201200.0,  # demand4_MW, multiplier 0.75
+            max(problem.get_timeseries("HeatingDemand_b0ff.target_heat_demand").values),
+        )
+        np.testing.assert_allclose(
+            720720.0,  # demand5_MW, multiplier 0.3
+            max(problem.get_timeseries("HeatingDemand_8fbe.target_heat_demand").values),
+        )
+        np.testing.assert_allclose(
+            916316.712,  # demand1_MW, multiplier 0.5
+            max(problem.get_timeseries("HeatingDemand_08fd.target_heat_demand").values),
+        )
+        np.testing.assert_allclose(
+            443413.79,  # demand4_MW, multiplier 0.75
+            np.average(problem.get_timeseries("HeatingDemand_b0ff.target_heat_demand").values),
+        )
+        np.testing.assert_allclose(
+            266048.27,  # demand5_MW, multiplier 0.3
+            np.average(problem.get_timeseries("HeatingDemand_8fbe.target_heat_demand").values),
+        )
+        np.testing.assert_allclose(
+            575570.74,  # demand1_MW, multiplier 0.5
+            np.average(problem.get_timeseries("HeatingDemand_08fd.target_heat_demand").values),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- it is known that with 150 heating demands that a lot of time (4 minutes) is being used to load all the profiles. But there was still some time spent after this before the goal programming started. After investigation it was discovered that  7 minutes were spent in pre() for heat_physics_mixin due to a lookup in a list in a pipe loop (648 pipes). The lookup of the list was replaced by a set() data structure instead (O(n) vs O(1))
- the reading of the 150 profiles occur per profile. Usually a couple of different profiles (1 type in this test case with 150 demand) are used which means there are not many unique profiles that have to be read from the database. Time for loading 1 profile is 4s and the time to setup the database connection etc is <0.0s. Therefore it was decided to focus on loading unique profile series data and only read series data for unique profiles. After the update the 4 minutes profile reading has been reduced to 20s for all the 150 profiles
- total optimization time was 32 mintes and after this update is takes 24 minutes when run only local machine. Originally this simulation took 42 minutes before the previous speedup updates.
- workflow used: EndScenarioSizingDiscountedStagedHIGHS