### PR TITLE
77 influxdb update request

### DIFF
--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -1,6 +1,7 @@
 import locale
 import logging
 import os
+import sys
 import time
 
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
@@ -344,7 +345,20 @@ class EndScenarioSizing(
         parameters = self.parameters(0)
         # bounds = self.bounds()
         # Optimized ESDL
-        self._write_updated_esdl(self._ESDLMixin__energy_system_handler.energy_system)
+        # Assume there are either no stages (write updated ESDL) or a 2 stages (only write final
+        # results on stage 2)
+        try:
+            if self._stage == 2:  # When staging does exists
+                self._write_updated_esdl(self._ESDLMixin__energy_system_handler.energy_system)
+            elif self._stage > 2:
+                logger.error(f"The code does not cater for a straging value of: {self._stage}")
+                sys.exit(1)
+        except AttributeError:
+            # Staging does not exist
+            self._write_updated_esdl(self._ESDLMixin__energy_system_handler.energy_system)
+        except Exception:
+            logger.error("Unkown error occured when evaluating self._stage for _write_updated_esdl")
+            sys.exit(1)
 
         for d in self.energy_system_components.get("heat_demand", []):
             realized_demand = results[f"{d}.Heat_demand"]

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -302,8 +302,14 @@ class ScenarioOutput(TechnoEconomicMixin):
         results = self.extract_results()
         parameters = self.parameters(0)
 
-        input_energy_system_id = energy_system.id
-        energy_system.id = str(uuid.uuid4())
+        _ = energy_system.id  # input energy system id. Kept here as not sure if still needed
+        energy_system.id = str(uuid.uuid4())  # output energy system id
+        output_energy_system_id = energy_system.id
+        # Currently the simulation_id is created here, but in the future this will probably move
+        # to account for 1 simulation/optimization/run potentialy generating more than 1 output
+        # energy system (ESDL)
+        simulation_id = str(uuid.uuid4())  # simulation (optimization/simulator etc) id
+
         if optimizer_sim:
             energy_system.name = energy_system.name + "_Simulation"
         else:
@@ -882,7 +888,7 @@ class ScenarioOutput(TechnoEconomicMixin):
                 port=self.influxdb_port,
                 username=self.influxdb_username,
                 password=self.influxdb_password,
-                database=input_energy_system_id,
+                database=output_energy_system_id,
                 ssl=self.influxdb_ssl,
                 verify_ssl=self.influxdb_verify_ssl,
             )
@@ -1103,7 +1109,7 @@ class ScenarioOutput(TechnoEconomicMixin):
                                         end_date_time = self.io.datetimes[-1]
 
                                     profile_attributes = esdl.InfluxDBProfile(
-                                        database=input_energy_system_id,
+                                        database=output_energy_system_id,
                                         measurement=asset_name,
                                         field=profiles.profile_header[-1],
                                         port=self.influxdb_port,
@@ -1193,7 +1199,7 @@ class ScenarioOutput(TechnoEconomicMixin):
                         )
 
                         optim_simulation_tag = {
-                            "simulationRun": energy_system.id,
+                            "simulationRun": simulation_id,
                             "simulation_type": type(self).__name__,
                             "assetId": asset_id,
                             "assetName": asset_name,


### PR DESCRIPTION
At request from Mark:
- only write updated esdl and influxdb results when the optimization is completed (last stage = 2)
- update influxdb profile result data (data base name now the output esdl id, unique optimization run id created and stored in database as well for future use)

This code was made available to Mark for use/testing so long via release 0.1.5.1