### PR TITLE
removed unfit check in log of postprocessing

### DIFF
--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3509,15 +3509,6 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
         parameters = self.parameters(0)
         options = self.energy_system_options()
 
-        # The flow directions are the same as the heat directions if the
-        # return (i.e. cold) line has zero heat throughout. Here we check that
-        # this is indeed the case.
-        for p in self.cold_pipes:
-            heat_in = results[f"{p}.HeatIn.Heat"]
-            heat_out = results[f"{p}.HeatOut.Heat"]
-            if np.any(heat_in > 1.0) or np.any(heat_out > 1.0):
-                logger.warning(f"Heat directions of pipes might be wrong. Check {p}.")
-
         if self.heat_network_settings["head_loss_option"] != HeadLossOption.NO_HEADLOSS:
             for p in self.energy_system_components.get("heat_pipe", []):
                 head_diff = results[f"{p}.HeatIn.H"] - results[f"{p}.HeatOut.H"]


### PR DESCRIPTION
Removed the warning as it is not fit for the purpose. Due to the use of absolute heat, the heat in the pipe is based on rho*cp*flow(Tcold - 0°C) +/- heatlosses.
This check was the result of old legacy.