### PR TITLE
update on the headloss equality constraints

### DIFF
--- a/src/mesido/head_loss_class.py
+++ b/src/mesido/head_loss_class.py
@@ -822,55 +822,43 @@ class HeadLossClass:
                         )
 
                     # Add equality constraint, value == 0.0 for all linear lines
-                    # Loop twice due to linear lines exsiting for negative and positive discharge
-                    # ii==0: this is the linear lines for the negative discharge possibility
-                    # ii==1: this is the linear lines for the postive discharge possibility
-                    for ii in range(2):
-                        for ii_line in range(n_linear_lines):
-                            ii_line_used = (ii * 2) + ii_line
-
-                            ii_start = (ii_line + 2 * ii) * n_timesteps
-                            ii_end = ii_start + n_timesteps
-                            constraints.append(
+                    for ii_line_used in range(len(pipe_linear_line_segment)):
+                        ii_start = ii_line_used * n_timesteps
+                        ii_end = ii_start + n_timesteps
+                        constraints.append(
+                            (
                                 (
-                                    (
-                                        head_loss_vec[ii_start:ii_end]
-                                        - (
-                                            a_vec[ii_start:ii_end] * discharge_vec[ii_start:ii_end]
-                                            + b_vec[ii_start:ii_end]
-                                        )
-                                        + is_disconnected_vec[ii_start:ii_end] * big_m_lin
-                                        + big_m_lin
-                                        * (1 - is_line_segment_active[ii_line_used][0:n_timesteps])
+                                    head_loss_vec[ii_start:ii_end]
+                                    - (
+                                        a_vec[ii_start:ii_end] * discharge_vec[ii_start:ii_end]
+                                        + b_vec[ii_start:ii_end]
                                     )
-                                    / constraint_nominal[ii_start:ii_end],
-                                    0.0,
-                                    np.inf,
-                                ),
-                            )
-                    for ii in range(2):
-                        for ii_line in range(n_linear_lines):
-                            ii_line_used = (ii * 2) + ii_line
-
-                            ii_start = (ii_line + 2 * ii) * n_timesteps
-                            ii_end = ii_start + n_timesteps
-                            constraints.append(
+                                    + is_disconnected_vec[ii_start:ii_end] * big_m_lin
+                                    + big_m_lin
+                                    * (1 - is_line_segment_active[ii_line_used][0:n_timesteps])
+                                )
+                                / constraint_nominal[ii_start:ii_end],
+                                0.0,
+                                np.inf,
+                            ),
+                        )
+                        constraints.append(
+                            (
                                 (
-                                    (
-                                        head_loss_vec[ii_start:ii_end]
-                                        - (
-                                            a_vec[ii_start:ii_end] * discharge_vec[ii_start:ii_end]
-                                            + b_vec[ii_start:ii_end]
-                                        )
-                                        - is_disconnected_vec[ii_start:ii_end] * big_m_lin
-                                        - big_m_lin
-                                        * (1 - is_line_segment_active[ii_line_used][0:n_timesteps])
+                                    head_loss_vec[ii_start:ii_end]
+                                    - (
+                                        a_vec[ii_start:ii_end] * discharge_vec[ii_start:ii_end]
+                                        + b_vec[ii_start:ii_end]
                                     )
-                                    / constraint_nominal[ii_start:ii_end],
-                                    -np.inf,
-                                    0.0,
-                                ),
-                            )
+                                    - is_disconnected_vec[ii_start:ii_end] * big_m_lin
+                                    - big_m_lin
+                                    * (1 - is_line_segment_active[ii_line_used][0:n_timesteps])
+                                )
+                                / constraint_nominal[ii_start:ii_end],
+                                -np.inf,
+                                0.0,
+                            ),
+                        )
                 return constraints
             else:
                 ret = np.amax(a * np.tile(discharge, (len(a), 1)).transpose() + b, axis=1)

--- a/src/mesido/workflows/multicommodity_simulator_workflow.py
+++ b/src/mesido/workflows/multicommodity_simulator_workflow.py
@@ -516,6 +516,7 @@ class MultiCommoditySimulator(
         self.gas_network_settings["head_loss_option"] = HeadLossOption.LINEARIZED_N_LINES_EQUALITY
         self.gas_network_settings["network_type"] = NetworkSettings.NETWORK_TYPE_HYDROGEN
         self.gas_network_settings["minimize_head_losses"] = False
+        self.gas_network_settings["maximum_velocity"] = 60.0
         options["include_asset_is_switched_on"] = True
         options["estimated_velocity"] = 7.5
 

--- a/src/mesido/workflows/multicommodity_simulator_workflow.py
+++ b/src/mesido/workflows/multicommodity_simulator_workflow.py
@@ -515,7 +515,7 @@ class MultiCommoditySimulator(
 
         self.gas_network_settings["head_loss_option"] = HeadLossOption.LINEARIZED_N_LINES_EQUALITY
         self.gas_network_settings["network_type"] = NetworkSettings.NETWORK_TYPE_HYDROGEN
-        self.gas_network_settings["minimize_head_losses"] = True
+        self.gas_network_settings["minimize_head_losses"] = False
         options["include_asset_is_switched_on"] = True
         options["estimated_velocity"] = 7.5
 


### PR DESCRIPTION
There was a bug in the headloss equality constraints, the loop over the pipe_line_segments was incorrect only going from 0-4 and then from 2-6 instead of 0-4 and 5-9.
There only seems to be a small scaling issue with highs in one of the tests, with other solvers it solves perfectly. (to be solved when merging to main)