### PR TITLE
Reduce frequency of pipeline runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 name: PyPi release
 run-name: CI pipeline
 on:
-  push:
+  pull_request:
     branches:
       - '*'
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   style:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   style:
     name: Check style
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     env:
       TOXENV: flake8,black
     steps:
@@ -32,6 +33,7 @@ jobs:
   build:
     name: Check build
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v3
 
@@ -49,6 +51,7 @@ jobs:
   test_main:
     name: Test main
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     env:
       TOXENV: py38
     steps:
@@ -68,6 +71,7 @@ jobs:
   test_pre_processing:
     name: Test pre-processing
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     env:
       TOXENV: py38
     steps:
@@ -103,6 +107,7 @@ jobs:
     name: Test post-processing
     needs: test_pre_processing
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     env:
       TOXENV: py38
     steps:
@@ -132,6 +137,7 @@ jobs:
   documentation:
     name: Generate documentation
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bugfix: No longer required to provide a power at the heating demands when a profile has been added.
 - Bugfix: Scaling fix on ATES temperature variable when temperature modelling not used.
 - Bugfix: Fix on nominals in electricity cables and gas pipes. Fix on nominals for nodes with logical links.
+- Pipeline is only run when pull request is ready for review and synchronized or when opened. 
  
 ## Fixed
 - Bug fix: machine error/rounding with updating lower bound values in the grow_workflow after stage 1


### PR DESCRIPTION
Update to only run when PR not in draft and synchronized or when opened.

Runs pipeline if a pull request exists and:
   pull_request
      - opened
      - reopened
      - synchronize (pushed)
      - marked ready_for_review
   
Exclusion made when the PR is still marked as draft.

When the PR is in draft all checks will be skipped. Therefore one will see it in the actions list, however with only 5 sec and with a 'skipped' sign.