### PR TITLE
186 order of ports e boiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bugfix: Fix on nominals in electricity cables and gas pipes. Fix on nominals for nodes with logical links.
  
 ## Fixed
+- Bug fix: e-boiler expected order of inports while setting nominal values
 - Bug fix: machine error/rounding with updating lower bound values in the grow_workflow after stage 1
 - documentation: heat physics tank storage
 - bug fix in grow_workflow (heat networks), changed minimum velocity from 0 to default value

--- a/src/mesido/esdl/asset_to_component_base.py
+++ b/src/mesido/esdl/asset_to_component_base.py
@@ -750,11 +750,12 @@ class _AssetToComponentBase:
                     elif isinstance(port.carrier, esdl.HeatCommodity):
                         q_nominals["Q_nominal"] = self._port_to_q_nominal[connected_port]
                         self._port_to_q_nominal[port] = q_nominals["Q_nominal"]
-                    else:
-                        logger.error(
-                            f"{asset.name} should have at least gas or heat specified on"
-                            f"one of the in ports"
-                        )
+                if not q_nominals:
+                    logger.error(
+                        f"{asset.name} should have at least gas or heat specified on"
+                        f"one of the in ports"
+                    )
+                    exit(1)
             except KeyError:
                 if isinstance(asset.out_ports[0].carrier, esdl.GasCommodity):
                     connected_port = asset.out_ports[0].connectedTo[0]

--- a/src/mesido/esdl/asset_to_component_base.py
+++ b/src/mesido/esdl/asset_to_component_base.py
@@ -743,7 +743,7 @@ class _AssetToComponentBase:
             q_nominals = {}
             try:
                 for port in asset.in_ports:
-                    connected_port = asset.in_ports[0].connectedTo[0]
+                    connected_port = port.connectedTo[0]
                     if isinstance(port.carrier, esdl.GasCommodity):
                         q_nominals["Q_nominal_gas"] = self._port_to_q_nominal[connected_port]
                         self._port_to_q_nominal[port] = q_nominals["Q_nominal_gas"]

--- a/tests/test_elec_boiler.py
+++ b/tests/test_elec_boiler.py
@@ -94,3 +94,9 @@ class TestElecBoiler(TestCase):
             parameters["HeatPump_d8fd.cop"] * results["HeatPump_d8fd.Power_consumed"],
             results["HeatPump_d8fd.Heat_source"] + 1.0e-6,
         )
+
+
+if __name__ == "__main__":
+    TestElecBoiler = TestElecBoiler()
+    TestElecBoiler.test_elec_boiler()
+    TestElecBoiler.test_air_water_hp_elec()


### PR DESCRIPTION
The existing code expected the inports to be in a specific order which is not always the case as learned in the KIP gas work