### PR TITLE
Bugs webinar example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [Unreleased] - 2024-12-02
+# [Unreleased] - 2024-12-11
 
 ## Added
 - xx
@@ -8,6 +8,17 @@
 
 ## Fixed
 - xx
+
+# [0.1.8.4] - 2024-12-11
+
+## Added
+- More of the existing classes added to __init_ for local runs using the grow_workflow
+
+## Changed
+- xxx
+
+## Fixed
+- Bugs: state update of heat pump & heat buffer volume update in ESDL, heat storage asset data output to influxDB   
 
 # [0.1.8.3] - 2024-12-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - xxx
 
 ## Fixed
-- Bugs: state update of heat pump & heat buffer volume update in ESDL, heat storage asset data output to influxDB   
+- Bugs: state update of heat pump, heat buffer volume & ates charge rates update in ESDL, heat storage asset data output to influxDB   
 
 # [0.1.8.3] - 2024-12-02
 

--- a/src/mesido/workflows/__init__.py
+++ b/src/mesido/workflows/__init__.py
@@ -1,7 +1,10 @@
 from .grow_workflow import (
     EndScenarioSizing,
     EndScenarioSizingDiscounted,
+    EndScenarioSizingDiscountedStaged,
     EndScenarioSizingHIGHS,
+    EndScenarioSizingHeadLossDiscounted,
+    EndScenarioSizingHeadLossDiscountedStaged,
     EndScenarioSizingStaged,
     SolverGurobi,
     SolverHIGHS,
@@ -19,7 +22,10 @@ from .simulator_workflow import (
 __all__ = [
     "EndScenarioSizing",
     "EndScenarioSizingDiscounted",
+    "EndScenarioSizingDiscountedStaged",
     "EndScenarioSizingHIGHS",
+    "EndScenarioSizingHeadLossDiscounted",
+    "EndScenarioSizingHeadLossDiscountedStaged",
     "EndScenarioSizingStaged",
     "SolverGurobi",
     "SolverHIGHS",

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -954,19 +954,23 @@ class ScenarioOutput:
                 *self.energy_system_components.get("heat_source", []),
                 *self.energy_system_components.get("ates", []),
                 *self.energy_system_components.get("heat_buffer", []),
+                *self.energy_system_components.get("heat_pump", []),
             ]:
                 asset = _name_to_asset(name)
                 asset_placement_var = self._asset_aggregation_count_var_map[name]
                 placed = np.round(results[asset_placement_var][0]) >= 1.0
                 max_size = results[self._asset_max_size_map[name]][0]
 
-                if asset in self.energy_system_components.get("heat_buffer", []):
+                if asset.name in self.energy_system_components.get("heat_buffer", []):
                     asset.capacity = max_size
                     asset.volume = max_size / (
                         parameters[f"{name}.cp"]
                         * parameters[f"{name}.rho"]
                         * parameters[f"{name}.dT"]
                     )
+                elif asset.name in self.energy_system_components.get("heat_pump", []):
+                    # Note: Electrical capacity and not the heat capacity
+                    asset.power = max(results["HeatPump_cc7b.Power_elec"])
                 else:
                     asset.power = max_size
                 if not placed:
@@ -1061,6 +1065,7 @@ class ScenarioOutput:
                 esdl.Conversion,
                 esdl.Consumer,
                 esdl.Producer,
+                esdl.Storage,
             ]
 
             for asset_name in [

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -962,8 +962,8 @@ class ScenarioOutput:
                 max_size = results[self._asset_max_size_map[name]][0]
 
                 if asset.name in self.energy_system_components.get("ates", []):
-                    asset.maxChargeRate = max(results[f"{name}.Heat_flow"])
-                    asset.maxDischargeRate = min(results[f"{name}.Heat_flow"])
+                    asset.maxChargeRate = results[f"{name}__max_size"][0]
+                    asset.maxDischargeRate = results[f"{name}__max_size"][0]
                 elif asset.name in self.energy_system_components.get("heat_buffer", []):
                     asset.capacity = max_size
                     asset.volume = max_size / (
@@ -973,7 +973,8 @@ class ScenarioOutput:
                     )
                 elif asset.name in self.energy_system_components.get("heat_pump", []):
                     # Note: Electrical capacity and not the heat capacity
-                    asset.power = max(results[f"{name}.Power_elec"])
+                    # TODO: in the future we need to cater for varying COP as well
+                    asset.power = results[f"{name}__max_size"][0] / parameters[f"{name}.COP"]
                 else:
                     asset.power = max_size
                 if not placed:

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -961,7 +961,10 @@ class ScenarioOutput:
                 placed = np.round(results[asset_placement_var][0]) >= 1.0
                 max_size = results[self._asset_max_size_map[name]][0]
 
-                if asset.name in self.energy_system_components.get("heat_buffer", []):
+                if asset.name in self.energy_system_components.get("ates", []):
+                    asset.maxChargeRate = max(results[f"{name}.Heat_flow"])
+                    asset.maxDischargeRate = min(results[f"{name}.Heat_flow"])
+                elif asset.name in self.energy_system_components.get("heat_buffer", []):
                     asset.capacity = max_size
                     asset.volume = max_size / (
                         parameters[f"{name}.cp"]
@@ -970,7 +973,7 @@ class ScenarioOutput:
                     )
                 elif asset.name in self.energy_system_components.get("heat_pump", []):
                     # Note: Electrical capacity and not the heat capacity
-                    asset.power = max(results["HeatPump_cc7b.Power_elec"])
+                    asset.power = max(results[f"{name}.Power_elec"])
                 else:
                     asset.power = max_size
                 if not placed:


### PR DESCRIPTION
This started with a bug that where the influxDB could not be updated when running the webinar demo
- Bugs: state update of heat pump & heat buffer volume update in ESDL, heat storage asset data output to influxDB   
- Update ates charge rates
- More of the existing classes added to __init_ for local runs using the grow_workflow

An issue has been created to ensure we create a test case for this to prevent this in the future