### PR TITLE
State info assets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ html_theme_options = {
     # Toc options
     'collapse_navigation': False,
     'sticky_navigation': False,
-    'navigation_depth': 3,
+    'navigation_depth': 4,
     'includehidden': False,
     'titles_only': False
 }

--- a/docs/dev_docs/esdl_conversion.rst
+++ b/docs/dev_docs/esdl_conversion.rst
@@ -1,0 +1,11 @@
+ESDL to MESDIO conversion
+=========================
+
+TODO intro to esdl conversion
+
+.. automodule:: mesido.esdl.esdl_model_base
+    :members:
+    :private-members:
+
+.. automodule:: mesido.esdl.esdl_heat_model
+    :members:

--- a/docs/dev_docs/esdl_conversion.rst
+++ b/docs/dev_docs/esdl_conversion.rst
@@ -1,7 +1,9 @@
 ESDL to MESDIO conversion
 =========================
 
-TODO intro to esdl conversion
+This section shows all the convert functions available to translate an ESDL asset to an asset in MESIDO. These convert
+functions take the attributes from the ESDL asset, optionally do some calculations with them, after which they are
+provided as modifiers to the MESIDO asset in the component library.
 
 .. automodule:: mesido.esdl.esdl_model_base
     :members:

--- a/docs/dev_docs/index.rst
+++ b/docs/dev_docs/index.rst
@@ -7,5 +7,6 @@ Developers documentation
    :caption: Contents:
 
    component_library_milp
+   esdl_conversion
    physics_mixins
    workflows

--- a/docs/dev_docs/physics_mixins.rst
+++ b/docs/dev_docs/physics_mixins.rst
@@ -1,4 +1,3 @@
-
 Physcis Modelling
 =================
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -4,6 +4,3 @@ Support
 
 Raise any issue on `Github <https://github.com/Multi-Energy-Systems-Optimization/mesido/issues>`_ such that we can address your problem.
 
-.. automodule:: mesido.esdl.esdl_heat_model
-    :members:
-

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -3,3 +3,7 @@ Support
 #######
 
 Raise any issue on `Github <https://github.com/Multi-Energy-Systems-Optimization/mesido/issues>`_ such that we can address your problem.
+
+.. automodule:: mesido.esdl.esdl_heat_model
+    :members:
+

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -1926,7 +1926,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
             *self.energy_system_components.get("ates", []),
             *self.energy_system_components.get("low_temperature_ates", []),
         ]:
-            max_var_types.add(["ates", "low_temperature_ates"])
+            max_var_types.update(["ates", "low_temperature_ates"])
             max_var = self._asset_max_size_map[a]
             max_heat = self.extra_variable(max_var, ensemble_member)
             if a in self.energy_system_components.get("ates", []):

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -2040,12 +2040,14 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                 )
             )
 
-        max_var_assets_not_included = [a for a in energy_system_component_types if a not in
-                                  max_var_types]
-        if len(max_var_assets_not_included)>=0:
-            logger.warning(f"The following asset types are not included in the maximum sizing "
-                           f"constraints {max_var_assets_not_included}")
-
+        max_var_assets_not_included = [
+            a for a in energy_system_component_types if a not in max_var_types
+        ]
+        if len(max_var_assets_not_included) >= 0:
+            logger.warning(
+                f"The following asset types are not included in the maximum sizing "
+                f"constraints {max_var_assets_not_included}"
+            )
 
         return constraints
 
@@ -2126,15 +2128,19 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                     # TODO: can we generalize to all possible components to avoid having to skip
                     #  joints and other components in the future?
                     continue
-                elif (self.energy_system_components_commodity.get(asset_name) ==
-                      NetworkSettings.NETWORK_TYPE_HEAT):
+                elif (
+                    self.energy_system_components_commodity.get(asset_name)
+                    == NetworkSettings.NETWORK_TYPE_HEAT
+                ):
                     state_var = self.state(f"{asset_name}.Heat_flow")
                     single_power = bounds[f"{asset_name}.Heat_flow"][1]
                     nominal_value = single_power
                     nominal_var = self.variable_nominal(f"{asset_name}.Heat_flow")
                 else:
-                    logger.warning(f"{asset_name} is not yet included in the optional asset path "
-                                   f"constraints")
+                    logger.warning(
+                        f"{asset_name} is not yet included in the optional asset path "
+                        f"constraints"
+                    )
                     continue
 
                 constraints = self.__add_optional_asset_path_constraints(

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -1,3 +1,5 @@
+import ast
+import inspect
 import logging
 import math
 from typing import Dict, Tuple, Type, Union
@@ -60,8 +62,6 @@ logger = logging.getLogger("mesido")
 class _ESDLInputException(Exception):
     pass
 
-import ast
-import inspect
 
 def docs_esdl_modifiers(class__):
     modifiers_dict = {}
@@ -70,11 +70,14 @@ def docs_esdl_modifiers(class__):
     def extract_asset_info(bod):
         if isinstance(bod.value, ast.Subscript):
             if isinstance(bod.value.value, ast.Attribute):
-                if (bod.value.value.attr == "attributes" and bod.value.value.value.id ==
-                        "asset" and isinstance(bod.targets[0], ast.Name)):
-                    input_dict[node.name][bod.targets[0].id] = (
-                        f"{bod.targets[0].id}:  asset.attributes[{bod.value.slice.value}]"
-                    )
+                if (
+                    bod.value.value.attr == "attributes"
+                    and bod.value.value.value.id == "asset"
+                    and isinstance(bod.targets[0], ast.Name)
+                ):
+                    input_dict[node.name][
+                        bod.targets[0].id
+                    ] = f"{bod.targets[0].id}:  asset.attributes[{bod.value.slice.value}]"
 
     ast_of_init: ast.Module = ast.parse(inspect.getsource(class__))
     for node in ast.walk(ast_of_init):
@@ -87,14 +90,17 @@ def docs_esdl_modifiers(class__):
                         for key in bod.value.keywords:
                             if isinstance(key.arg, str):
                                 modifiers_dict[node.name].append(key.arg)
-                            elif key.arg == None and isinstance(key.value, ast.Call) and isinstance(
-                                    key.value.func, ast.Attribute):
+                            elif (
+                                key.arg is None
+                                and isinstance(key.value, ast.Call)
+                                and isinstance(key.value.func, ast.Attribute)
+                            ):
                                 modifiers_dict[node.name].append(key.value.func.attr)
                     else:
                         extract_asset_info(bod)
 
             func = getattr(class__, node.name)
-            if len(modifiers_dict[node.name]) >0:
+            if len(modifiers_dict[node.name]) > 0:
                 line_with_hook = next(
                     (
                         line
@@ -107,24 +113,13 @@ def docs_esdl_modifiers(class__):
                     indent = ""
                 else:
                     format_modifiers_dict = [f"* {mod}" for mod in modifiers_dict[node.name]]
-                    (indent, _) = line_with_hook.split(
-                        "{automatically_add_modifiers_here}")
+                    (indent, _) = line_with_hook.split("{automatically_add_modifiers_here}")
                     func.__doc__ = func.__doc__.replace(
                         "{automatically_add_modifiers_here}",
                         f"\n{indent}".join(format_modifiers_dict),
                     )
 
-            # TODO: the input dictionary is still in progress and not as easy to extract by code I
-            # believe
-            # if len(input_dict[node.name]) >0:
-            #     func.__doc__ += "\n\n ESDL input"
-            #     # format_list_string = ("\n         * "+ f"\n         * ".join(input_dict[
-            #     #                                                                 node.name].keys()).join(input_dict[
-            #     #                            node.name].values()))
-            #     format_list_string = ("\n         * " + f"\n         * ".join(input_dict[
-            #                                                                       node.name].values()))
-            #     func.__doc__ += format_list_string
-
+            # TODO: the input dictionary is still needed in the documentation
     return class__
 
 
@@ -135,6 +130,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
     objects and set their respective properties.
 
     """
+
     def __init__(
         self,
         *args,
@@ -1179,9 +1175,9 @@ class AssetToHeatComponent(_AssetToComponentBase):
 
             - Setting the CO2 emission coefficient in case this is specified as an KPI
             - Setting a caps on the thermal power.
-            - In case of a GeothermalSource object we read the _aggregation count to model the number
-            of doublets, we then assume that the power specified was also for one doublet and thus
-            increase the thermal power caps.
+            - In case of a GeothermalSource object we read the _aggregation count to model the
+            number of doublets, we then assume that the power specified was also for one doublet
+            and thus increase the thermal power caps.
             - Setting the state (enabled, disabled, optional)
             - Setting the relevant temperatures.
             - Setting the relevant cost figures.
@@ -1298,8 +1294,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
             - Setting a caps on the thermal power.
             - Similar as for the geothermal source we use the aggregation count to model the amount
             of doublets.
-            - Setting caps on the maximum stored energy where we assume that at maximum you can charge
-            for 180 days at full power.
+            - Setting caps on the maximum stored energy where we assume that at maximum you can
+            charge for 180 days at full power.
             - Setting the state (enabled, disabled, optional)
             - Setting the relevant temperatures.
             - Setting the relevant cost figures.

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -95,18 +95,35 @@ def docs_esdl_modifiers(class__):
 
             func = getattr(class__, node.name)
             if len(modifiers_dict[node.name]) >0:
-                format_list_string = "\n         * "+ f"\n         * ".join(modifiers_dict[node.name])
-                func.__doc__ += format_list_string
+                line_with_hook = next(
+                    (
+                        line
+                        for line in func.__doc__.splitlines()
+                        if "{" "automatically_add_modifiers_here}" in line
+                    ),
+                    None,
+                )
+                if line_with_hook is None:
+                    indent = ""
+                else:
+                    format_modifiers_dict = [f"* {mod}" for mod in modifiers_dict[node.name]]
+                    (indent, _) = line_with_hook.split(
+                        "{automatically_add_modifiers_here}")
+                    func.__doc__ = func.__doc__.replace(
+                        "{automatically_add_modifiers_here}",
+                        f"\n{indent}".join(format_modifiers_dict),
+                    )
+
             # TODO: the input dictionary is still in progress and not as easy to extract by code I
             # believe
-            if len(input_dict[node.name]) >0:
-                func.__doc__ += "\n\n ESDL input"
-                # format_list_string = ("\n         * "+ f"\n         * ".join(input_dict[
-                #                                                                 node.name].keys()).join(input_dict[
-                #                            node.name].values()))
-                format_list_string = ("\n         * " + f"\n         * ".join(input_dict[
-                                                                                  node.name].values()))
-                func.__doc__ += format_list_string
+            # if len(input_dict[node.name]) >0:
+            #     func.__doc__ += "\n\n ESDL input"
+            #     # format_list_string = ("\n         * "+ f"\n         * ".join(input_dict[
+            #     #                                                                 node.name].keys()).join(input_dict[
+            #     #                            node.name].values()))
+            #     format_list_string = ("\n         * " + f"\n         * ".join(input_dict[
+            #                                                                       node.name].values()))
+            #     func.__doc__ += format_list_string
 
     return class__
 
@@ -147,9 +164,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
         """
         For giving the density, rho, in kg/m3 and specic milp, cp, in J/(K*kg)
 
-        Returns
-        -------
-        rho and cp
+        Returns:
+            rho and cp
         """
         return dict(rho=self.rho, cp=self.cp)
 
@@ -163,6 +179,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
     ) -> float:
         """
         Get the value of the specified attribute for the given asset.
+
         Args:
             asset: The asset to retrieve the attribute value for.
             attribute_name: The name of the attribute to retrieve.
@@ -241,37 +258,35 @@ class AssetToHeatComponent(_AssetToComponentBase):
         - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - volume/capacity
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - volume/capacity
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - max(Dis)ChargeRate
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - max(Dis)ChargeRate
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
 
-        Returns
-        -------
-        Buffer class with modifiers
+        Parameters:
+            asset : The asset object with its properties.
+
+        Returns:
+            Buffer class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type == "HeatStorage"
 
@@ -370,42 +385,39 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the demand object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting a cap on the thermal power.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting a cap on the thermal power.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - power
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - power
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Demand class with modifiers
+        Returns:
+            Demand class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"GenericConsumer", "HeatingDemand", "Losses"}
 
@@ -432,18 +444,17 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the airco object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting a cap on the thermal power.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting a cap on the thermal power.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Demand class with modifiers
+        Returns:
+            Demand class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"Airco"}
 
@@ -469,16 +480,16 @@ class AssetToHeatComponent(_AssetToComponentBase):
         """
         This function converts the demand object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
-        - Setting a cap on the thermal power.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
-        Parameters
-        ----------
-        asset : The asset object with its properties.
-        Returns
-        -------
-        Demand class with modifiers
+            - Setting a cap on the thermal power.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
+
+        Parameters:
+            asset : The asset object with its properties.
+        Returns:
+            Demand class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"CoolingDemand"}
 
@@ -508,35 +519,32 @@ class AssetToHeatComponent(_AssetToComponentBase):
         - Setting the amount of connections
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with (note only one inport and one outport):
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo (allowed to have multiple connections)
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with (note only one inport and one outport):
+                - xsi:type
+                - id
+                - name
+                - connectedTo (allowed to have multiple connections)
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Node class with modifiers
+        Returns:
+            Node class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type == "Joint"
 
@@ -600,44 +608,41 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the pipe object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the dimensions of the pipe needed for head loss computation.
-        - setting if a pipe is disconnecteable for the optimization.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant pressure.
-        - Setting the relevant cost figures.
+            - Setting the dimensions of the pipe needed for head loss computation.
+            - setting if a pipe is disconnecteable for the optimization.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant pressure.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - Diameter/inner_diameter [m]
-        - length [m]
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with (note only one inport and one outport):
+            - Diameter/inner_diameter [m]
+            - length [m]
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with (note only one inport and one outport):
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Pipe class with modifiers
+        Returns:
+            Pipe class with modifiers:
+                {automatically_add_modifiers_here}
         """
 
         length = asset.attributes["length"]
@@ -686,48 +691,45 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the pipe object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the dimensions of the pipe needed for milp loss computation. Currently, assume
-        cylinder with height equal to radius.
-        - setting if a pipe is disconnecteable for the optimization.
-        - Setting the isolative properties of the pipe.
-        - Setting a cap on the thermal power.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the dimensions of the pipe needed for milp loss computation. Currently, assume
+            cylinder with height equal to radius.
+            - setting if a pipe is disconnecteable for the optimization.
+            - Setting the isolative properties of the pipe.
+            - Setting a cap on the thermal power.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - Diameter/inner_diameter [m]
-        - length [m]
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with (note only one inport and one outport):
+            - Diameter/inner_diameter [m]
+            - length [m]
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with (note only one inport and one outport):
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - Material (for insulation)
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - Material (for insulation)
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Pipe class with modifiers
+        Returns:
+            Pipe class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type == "Pipe"
 
@@ -808,40 +810,37 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the pump object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with (note only one inport and one outport):
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with (note only one inport and one outport):
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Pump class with modifiers
+        Returns:
+            Pump class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type == "Pump"
 
@@ -875,13 +874,12 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function determines the type to which the generic conversion should be changed, based
         on the connected commodities and calls the required conversion function.
 
-        Parameters
-        ----------
-        asset: The asset object with its properties.
+        Parameters:
+            asset: The asset object with its properties.
 
-        Returns
-        -------
-        Transformer class or HeatExchanger class with modifiers
+        Returns:
+            Transformer class or HeatExchanger class with modifiers:
+                {automatically_add_modifiers_here}
         """
 
         assert asset.asset_type in {
@@ -911,44 +909,41 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the Heat Exchanger object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - Setting the thermal power transfer efficiency.
-        - Setting a caps on the thermal power on both the primary and secondary side.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures (also checked for making sense physically).
-        - Setting the relevant cost figures.
+            - Setting the thermal power transfer efficiency.
+            - Setting a caps on the thermal power on both the primary and secondary side.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures (also checked for making sense physically).
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - heatTransferCoefficient/power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - 2 InPorts and 2 OutPorts with:
+            - heatTransferCoefficient/power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - 2 InPorts and 2 OutPorts with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - efficiency
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - efficiency
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        HeatExchanger class with modifiers
+        Returns:
+            HeatExchanger class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {
             "GenericConversion",
@@ -1070,46 +1065,43 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the HeatPump object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the COP of the heatpump
-        - Setting the cap on the electrical power.
-        - Setting a caps on the thermal power on both the primary and secondary side.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the COP of the heatpump
+            - Setting the cap on the electrical power.
+            - Setting a caps on the thermal power on both the primary and secondary side.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - COP
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - 2 InPorts and 2 OutPorts with:
+            - power
+            - COP
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - 2 InPorts and 2 OutPorts with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - efficiency
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - efficiency
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        HeatPump class with modifiers
+        Returns:
+            HeatPump class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {
             "HeatPump",
@@ -1185,47 +1177,44 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the Source object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the CO2 emission coefficient in case this is specified as an KPI
-        - Setting a caps on the thermal power.
-        - In case of a GeothermalSource object we read the _aggregation count to model the number
-        of doublets, we then assume that the power specified was also for one doublet and thus
-        increase the thermal power caps.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the CO2 emission coefficient in case this is specified as an KPI
+            - Setting a caps on the thermal power.
+            - In case of a GeothermalSource object we read the _aggregation count to model the number
+            of doublets, we then assume that the power specified was also for one doublet and thus
+            increase the thermal power caps.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - aggregationCount
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - aggregationCount
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Source class with modifiers
+        Returns:
+            Source class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {
             "GasHeater",
@@ -1304,50 +1293,47 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the ATES object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the milp loss coefficient based upon the efficiency. Here we assume that this
-        efficiency is realized in 100 days.
-        - Setting a caps on the thermal power.
-        - Similar as for the geothermal source we use the aggregation count to model the amount
-        of doublets.
-        - Setting caps on the maximum stored energy where we assume that at maximum you can charge
-        for 180 days at full power.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the milp loss coefficient based upon the efficiency. Here we assume that this
+            efficiency is realized in 100 days.
+            - Setting a caps on the thermal power.
+            - Similar as for the geothermal source we use the aggregation count to model the amount
+            of doublets.
+            - Setting caps on the maximum stored energy where we assume that at maximum you can charge
+            for 180 days at full power.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - max(Dis)ChargeRate
-        - aquiferMidTemperature
-        - aggregationCount
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - max(Dis)ChargeRate
+            - aquiferMidTemperature
+            - aggregationCount
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ATES class with modifiers
+        Returns:
+            ATES class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {
             "ATES",
@@ -1452,40 +1438,37 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the ControlValve object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ControlValve class with modifiers
+        Returns:
+            ControlValve class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type == "Valve"
 
@@ -1517,40 +1500,37 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the CheckValve object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        CheckValve class with modifiers
+        Returns:
+            CheckValve class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type == "CheckValve"
 
@@ -1572,39 +1552,36 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the ElectricityDemand object in esdl to a set of modifiers that can
         be used in a pycml object. Most important:
 
-        - Setting the electrical power caps
+            - Setting the electrical power caps
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with voltage specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with voltage specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ElectricityDemand class with modifiers
+        Returns:
+            ElectricityDemand class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"ElectricityDemand", "Export"}
 
@@ -1671,39 +1648,36 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the ElectricitySource object in esdl to a set of modifiers that can
         be used in a pycml object. Most important:
 
-        - Setting the electrical power caps
+            - Setting the electrical power caps
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with voltage specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with voltage specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ElectricitySource class with modifiers
+        Returns:
+            ElectricitySource class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {
             "ElectricityProducer",
@@ -1747,13 +1721,12 @@ class AssetToHeatComponent(_AssetToComponentBase):
 
         - Setting the electrical power caps
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ElectricityStorage class with modifiers
+        Returns:
+            ElectricityStorage class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"Battery"}
 
@@ -1790,38 +1763,35 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the ElectricityNode object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - Setting the number of connections
+            - Setting the number of connections
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo (allowed to have multiple connections)
-            - carrier with voltage specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo (allowed to have multiple connections)
+                - carrier with voltage specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ElectricityNode class with modifiers
+        Returns:
+            ElectricityNode class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"Bus"}
 
@@ -1856,41 +1826,38 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the ElectricityCable object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - Setting the length of the cable used for power loss computation.
-        - setting the min and max current.
+            - Setting the length of the cable used for power loss computation.
+            - setting the min and max current.
 
         Required ESDL fields:
-        ---------------------
-        - length
-        - capacity
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - length
+            - capacity
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with voltage specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with voltage specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ElectricityCable class with modifiers
+        Returns:
+            ElectricityCable class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"ElectricityCable"}
 
@@ -1938,16 +1905,15 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the Transformer object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - Setting the length of the cable used for power loss computation.
-        - setting the min and max current.
+            - Setting the length of the cable used for power loss computation.
+            - setting the min and max current.
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        ElectricityCable class with modifiers
+        Returns:
+            ElectricityCable class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"Transformer", "GenericConversion"}
         self._get_connected_i_nominal_and_max(asset)
@@ -1982,35 +1948,32 @@ class AssetToHeatComponent(_AssetToComponentBase):
         - ...
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with pressure specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with pressure specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        GasDemand class with modifiers
+        Returns:
+            GasDemand class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"GasDemand", "Export"}
 
@@ -2058,35 +2021,32 @@ class AssetToHeatComponent(_AssetToComponentBase):
         - ...
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with pressure specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with pressure specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        GasDemand class with modifiers
+        Returns:
+            GasDemand class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"GasProducer", "Import"}
 
@@ -2125,42 +2085,39 @@ class AssetToHeatComponent(_AssetToComponentBase):
         used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - minLoad
-        - maxLoad
-        - effMinLoad
-        - effMaxLoad
-        - efficiency
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - minLoad
+            - maxLoad
+            - effMinLoad
+            - effMaxLoad
+            - efficiency
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with voltage/pressure specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with voltage/pressure specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - powerFactor
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - powerFactor
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Electrolyzer class with modifiers
+        Returns:
+            Electrolyzer class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"Electrolyzer"}
 
@@ -2239,36 +2196,33 @@ class AssetToHeatComponent(_AssetToComponentBase):
         used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - workingVolume
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - workingVolume
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with pressure specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with pressure specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        GasTankStorage class with modifiers
+        Returns:
+            GasTankStorage class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"GasStorage"}
 
@@ -2307,35 +2261,32 @@ class AssetToHeatComponent(_AssetToComponentBase):
         can be used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with pressure specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with pressure specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        GasSubstation class with modifiers
+        Returns:
+            GasSubstation class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"GasConversion", "PressureReducingValve"}
 
@@ -2374,35 +2325,32 @@ class AssetToHeatComponent(_AssetToComponentBase):
         used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with pressure specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with pressure specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        Compressor class with modifiers
+        Returns:
+            Compressor class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"Compressor"}
 
@@ -2441,36 +2389,33 @@ class AssetToHeatComponent(_AssetToComponentBase):
         used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with pressure/temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with pressure/temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        GasBoiler class with modifiers
+        Returns:
+            GasBoiler class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"GasHeater"}
 
@@ -2531,36 +2476,33 @@ class AssetToHeatComponent(_AssetToComponentBase):
         used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with voltage/temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with voltage/temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        GasBoiler class with modifiers
+        Returns:
+            GasBoiler class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"ElectricBoiler"}
 
@@ -2628,37 +2570,34 @@ class AssetToHeatComponent(_AssetToComponentBase):
         used in a pycml object.
 
         Required ESDL fields:
-        ---------------------
-        - power
-        - id (this id must be unique)
-        - name (this name must be unique)
-        - xsi:type
-        - State
-        - InPort and OutPort with:
+            - power
+            - id (this id must be unique)
+            - name (this name must be unique)
             - xsi:type
-            - id
-            - name
-            - connectedTo
-            - carrier with voltage/temperature specified
+            - State
+            - InPort and OutPort with:
+                - xsi:type
+                - id
+                - name
+                - connectedTo
+                - carrier with voltage/temperature specified
 
         Optional ESDL fields:
-        ---------------------
-        - COP
-        - technicalLifetime
-        - CostInformation: discountRate
-        - CostInformation: marginalCost
-        - CostInformation: installationCost
-        - CostInformation: investmentCost
-        - CostInformation: fixedOperationalCost
-        - CostInformation: variableOperationalCost
+            - COP
+            - technicalLifetime
+            - CostInformation: discountRate
+            - CostInformation: marginalCost
+            - CostInformation: installationCost
+            - CostInformation: investmentCost
+            - CostInformation: fixedOperationalCost
+            - CostInformation: variableOperationalCost
 
-        Parameters
-        ----------
-        asset : The asset object with its properties.
+        Parameters:
+            asset : The asset object with its properties.
 
-        Returns
-        -------
-        AirWaterHeatPumpElec class with modifiers
+        Returns:
+            AirWaterHeatPumpElec class with modifiers:
+                {automatically_add_modifiers_here}
         """
         assert asset.asset_type in {"HeatPump"}
 

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -97,6 +97,8 @@ def docs_esdl_modifiers(class__):
             if len(modifiers_dict[node.name]) >0:
                 format_list_string = "\n         * "+ f"\n         * ".join(modifiers_dict[node.name])
                 func.__doc__ += format_list_string
+            # TODO: the input dictionary is still in progress and not as easy to extract by code I
+            # believe
             if len(input_dict[node.name]) >0:
                 func.__doc__ += "\n\n ESDL input"
                 # format_list_string = ("\n         * "+ f"\n         * ".join(input_dict[

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -244,14 +244,14 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the buffer object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-        - Setting the dimensions of the buffer needed for milp loss computation. Currently, assume
-        cylinder with height equal to radius.
-        - setting a minimum fill level and minimum asscociated milp
-        - Setting a maximum stored energy based on the size.
-        - Setting a cap on the thermal power.
-        - Setting the state (enabled, disabled, optional)
-        - Setting the relevant temperatures.
-        - Setting the relevant cost figures.
+            - Setting the dimensions of the buffer needed for heat loss computation. Currently,
+              assume cylinder with height equal to radius.
+            - setting a minimum fill level and minimum asscociated milp
+            - Setting a maximum stored energy based on the size.
+            - Setting a cap on the thermal power.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant temperatures.
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
             - volume/capacity
@@ -687,8 +687,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the pipe object in esdl to a set of modifiers that can be used in
         a pycml object. Most important:
 
-            - Setting the dimensions of the pipe needed for milp loss computation. Currently, assume
-            cylinder with height equal to radius.
+            - Setting the dimensions of the pipe needed for milp loss computation. Currently,
+            assume cylinder with height equal to radius.
             - setting if a pipe is disconnecteable for the optimization.
             - Setting the isolative properties of the pipe.
             - Setting a cap on the thermal power.
@@ -874,8 +874,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             asset: The asset object with its properties.
 
         Returns:
-            Transformer class or HeatExchanger class with modifiers:
-                {automatically_add_modifiers_here}
+            Transformer class or HeatExchanger class
         """
 
         assert asset.asset_type in {
@@ -1176,8 +1175,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
             - Setting the CO2 emission coefficient in case this is specified as an KPI
             - Setting a caps on the thermal power.
             - In case of a GeothermalSource object we read the _aggregation count to model the
-            number of doublets, we then assume that the power specified was also for one doublet
-            and thus increase the thermal power caps.
+              number of doublets, we then assume that the power specified was also for one doublet
+              and thus increase the thermal power caps.
             - Setting the state (enabled, disabled, optional)
             - Setting the relevant temperatures.
             - Setting the relevant cost figures.
@@ -1290,12 +1289,12 @@ class AssetToHeatComponent(_AssetToComponentBase):
         a pycml object. Most important:
 
             - Setting the milp loss coefficient based upon the efficiency. Here we assume that this
-            efficiency is realized in 100 days.
+              efficiency is realized in 100 days.
             - Setting a caps on the thermal power.
             - Similar as for the geothermal source we use the aggregation count to model the amount
-            of doublets.
+              of doublets.
             - Setting caps on the maximum stored energy where we assume that at maximum you can
-            charge for 180 days at full power.
+              charge for 180 days at full power.
             - Setting the state (enabled, disabled, optional)
             - Setting the relevant temperatures.
             - Setting the relevant cost figures.
@@ -1941,7 +1940,10 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the GasDemand object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - ...
+            - Setting a cap on the mass flow produced.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant cost figures.
+
 
         Required ESDL fields:
             - id (this id must be unique)
@@ -2014,7 +2016,9 @@ class AssetToHeatComponent(_AssetToComponentBase):
         This function converts the GasDemand object in esdl to a set of modifiers that can be
         used in a pycml object. Most important:
 
-        - ...
+            - Setting a cap on the mass flow produced.
+            - Setting the state (enabled, disabled, optional)
+            - Setting the relevant cost figures.
 
         Required ESDL fields:
             - id (this id must be unique)

--- a/src/mesido/esdl/esdl_model_base.py
+++ b/src/mesido/esdl/esdl_model_base.py
@@ -34,15 +34,11 @@ class _ESDLModelBase(_Model):
         at the connections specified in the esdl and create the relevant maps between ports to then
         also connect the pycml ports of the assets.
 
-        Parameters
-        ----------
-        converter : class with the different converter functions for all asset types.
-        assets : a dict with all the parsed esdl assets and their attributes
-        prefix : prefix for the name of the model type Heat or QTH at the moment
+        Parameters:
+            converter : class with the different converter functions for all asset types.
+            assets : a dict with all the parsed esdl assets and their attributes
+            prefix : prefix for the name of the model type Heat or QTH at the moment
 
-        Returns
-        -------
-        None
         """
         # Sometimes we need information of one component in order to convert
         # another. For example, the nominal discharge of a pipe is used to set


### PR DESCRIPTION
Adding state to asset info in esdl modifiers if it was missing.

Created method to update the documentation of the convert function with the modifiers that are returned to the asset.