### PR TITLE
change definition of power value of heat pump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# [Unreleased-main] - 2025-04-15
+# [Unreleased-main] - 2025-05-07
 
 ## Added
 - Default database for gas pipe dimensions based on the ASA pipe schedule with thicknesses from the standard class
@@ -25,6 +25,7 @@
 - Option for electricity cables to be unidirectional
 - Upgraded rtctools to v 2.6.1
 - Updated Casadi to 3.6.7 with gil fixes (see https://github.com/casadi/casadi/releases/tag/nightly-gil_release)
+- Definition of power attribute of water-to-water heat pump is changed from electrical power to secondary heat power
 
 ## Fixed
 - Bugfix: gas boiler mass flow constraint units

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -1124,7 +1124,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             raise _ESDLInputException(f"{asset.name} has no power specified")
         else:
             power_secondary = asset.attributes["power"]
-            power_electrical = power_secondary/cop
+            power_electrical = power_secondary / cop
 
         params_t = self._supply_return_temperature_modifiers(asset)
         params_q = self._get_connected_q_nominal(asset)

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -1113,17 +1113,18 @@ class AssetToHeatComponent(_AssetToComponentBase):
             _, modifiers = self.convert_air_water_heat_pump_elec(asset)
             return AirWaterHeatPumpElec, modifiers
 
-        if not asset.attributes["power"]:
-            raise _ESDLInputException(f"{asset.name} has no power specified")
-        else:
-            power_electrical = asset.attributes["power"]
-
         if not asset.attributes["COP"]:
             raise _ESDLInputException(
                 f"{asset.name} has not COP specified, this is required for the model"
             )
         else:
             cop = asset.attributes["COP"]
+
+        if not asset.attributes["power"]:
+            raise _ESDLInputException(f"{asset.name} has no power specified")
+        else:
+            power_secondary = asset.attributes["power"]
+            power_electrical = power_secondary/cop
 
         params_t = self._supply_return_temperature_modifiers(asset)
         params_q = self._get_connected_q_nominal(asset)

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -1115,7 +1115,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
 
         if not asset.attributes["COP"]:
             raise _ESDLInputException(
-                f"{asset.name} has not COP specified, this is required for the model"
+                f"{asset.name} has no COP specified, this is required for the model"
             )
         else:
             cop = asset.attributes["COP"]

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -975,9 +975,9 @@ class ScenarioOutput:
                         * parameters[f"{name}.dT"]
                     )
                 elif asset.name in self.energy_system_components.get("heat_pump", []):
-                    # Note: Electrical capacity and not the heat capacity
+                    # Note: The heat capacity and not the electrical capacity
                     # TODO: in the future we need to cater for varying COP as well
-                    asset.power = results[f"{name}__max_size"][0] / parameters[f"{name}.COP"]
+                    asset.power = results[f"{name}__max_size"][0]
                 else:
                     asset.power = max_size
                 if not placed:


### PR DESCRIPTION
Adds a new definition to the power attribute of heat pump. Previously, heat pump power attribute was defining the maximum electrical power of heat pump. Now, it defines the maximum heat power of the secondary side.