### PR TITLE
moved location of potential error reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# [Unreleased-main] - 2025-04-15
+# [Unreleased-main] - 2025-05-07
 
 ## Added
 - Default database for gas pipe dimensions based on the ASA pipe schedule with thicknesses from the standard class

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -150,9 +150,9 @@ class EndScenarioSizing(
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
         reset_potential_errors()  # This needed to clear the Singleton which is persistent
+
+        super().__init__(*args, **kwargs)
 
         # default setting to cater for ~ 10kW heat, DN800 pipe at dT = 40 degrees Celcuis
         self.heat_network_settings["minimum_velocity"] = 1.0e-4


### PR DESCRIPTION
The persistent object reset had to be moved because it will reset potential errors created in asset_to_component_base.py -> work in progress in another branch 