### PR TITLE
Heat pump power upper bound is defined as the upper bound of heat pum…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# [Unreleased-main] - 2025-05-07
+# [Unreleased-main] - 2025-05-16
 
 ## Added
 - Default database for gas pipe dimensions based on the ASA pipe schedule with thicknesses from the standard class
@@ -26,6 +26,7 @@
 - Upgraded rtctools to v 2.6.1
 - Updated Casadi to 3.6.7 with gil fixes (see https://github.com/casadi/casadi/releases/tag/nightly-gil_release)
 - Definition of power attribute of water-to-water heat pump is changed from electrical power to secondary heat power
+- Enforce water-to-water heat pump upper bound heat capacity to conform the elect_power*cop
 
 ## Fixed
 - Bugfix: gas boiler mass flow constraint units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Upgraded rtctools to v 2.6.1
 - Updated Casadi to 3.6.7 with gil fixes (see https://github.com/casadi/casadi/releases/tag/nightly-gil_release)
 - Definition of power attribute of water-to-water heat pump is changed from electrical power to secondary heat power
-- Enforce water-to-water heat pump upper bound heat capacity to conform the elect_power*cop
+- Enforce water-to-water heat pump upper bound heat capacity to conform to elect_power*cop
 
 ## Fixed
 - Bugfix: gas boiler mass flow constraint units

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -1140,7 +1140,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
         params["Primary"] = {**params_t["Primary"], **params_q["Primary"], **prim_heat}
         params["Secondary"] = {**params_t["Secondary"], **params_q["Secondary"], **sec_heat}
 
-        max_power = power_secondary
+        max_power_heat = power_secondary
 
         modifiers = dict(
             COP=cop,
@@ -1156,9 +1156,9 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
             ),
             Power_elec=dict(min=0.0, max=power_electrical, nominal=power_electrical / 2.0),
-            Primary_heat=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
-            Secondary_heat=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
-            Heat_flow=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
+            Primary_heat=dict(min=0.0, max=max_power_heat, nominal=max_power_heat / 2.0),
+            Secondary_heat=dict(min=0.0, max=max_power_heat, nominal=max_power_heat / 2.0),
+            Heat_flow=dict(min=0.0, max=max_power_heat, nominal=max_power_heat / 2.0),
             state=self.get_state(asset),
             **self._get_cost_figure_modifiers(asset),
             **params,

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -1140,7 +1140,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
         params["Primary"] = {**params_t["Primary"], **params_q["Primary"], **prim_heat}
         params["Secondary"] = {**params_t["Secondary"], **params_q["Secondary"], **sec_heat}
 
-        max_power = power_electrical * (1.0 + cop)  # TODO: dit kan zijn power_electrical*cop
+        max_power = power_secondary
 
         modifiers = dict(
             COP=cop,

--- a/tests/test_multiple_in_and_out_port_components.py
+++ b/tests/test_multiple_in_and_out_port_components.py
@@ -313,6 +313,8 @@ class TestHP(TestCase):
         - Standard checks for demand matching, heat to discharge and energy conservation
         - Check that the heat pump is producing according to its COP
         - Check that Secondary source use in minimized
+        - Check that the upper bound value for heat producing capacity is the same as specified in
+        the esdl
 
 
         """
@@ -383,6 +385,14 @@ class TestHP(TestCase):
         # We check the energy converted betweeen the commodities
         np.testing.assert_allclose(power_elec * parameters["GenericConversion_3d3f.COP"], sec_heat)
         np.testing.assert_allclose(power_elec + prim_heat, sec_heat)
+
+        # Check that the heat pump upper bound
+        for key in solution.esdl_assets.keys():
+            if solution.esdl_assets[key].asset_type == "HeatPump":
+                np.testing.assert_equal(
+                    solution.bounds()["GenericConversion_3d3f.Heat_flow"][1],
+                    solution.esdl_assets[key].attributes["power"],
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updated the upper bound of secondary heat of water-to-water heat pump. 
Previously it was defined as: electrical_power * (cop + 1).
Now it is : electrical_power * cop