### PR TITLE
Bug fix to prevent asset sizing when state=ENABLED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [Unreleased-main] - 2025-06-12
+# [Unreleased-main] - 2025-06-25
 
 ## Added
 - xx
@@ -7,7 +7,19 @@
 - xx
 
 ## Fixed
+- xxx
+
+
+# [0.1.13] - 2025-06-25
+
+## Added
 - xx
+
+## Changed
+- xx
+
+## Fixed
+- Bug: Producer profiles specified in Watts and asset state=ENABLED
 
 
 # [0.1.12] - 2025-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - xx
 
 ## Changed
-- xx
+- README update mesido install command for dev
 
 ## Fixed
 - Bug: Producer profiles specified in Watts and asset state=ENABLED

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you are going to develop and change the source code, you probably want to do 
 
 	# 1b. Use git clone and pip to make an editable/developer installation
 	git clone https://github.com/Multi-Energy-Systems-Optimization/mesido
-	pip install -e mesido
+	python -m pip install -e .
 
 MESIDO depends on `RTC-Tools <https://gitlab.com/deltares/rtc-tools.git>`_, which is automatically installed as one of its dependencies.
 

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -807,6 +807,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                 and hasattr(esdl_asset_attributes.items[0], "maximum")
                 and esdl_asset_attributes.items[0].maximum.profileQuantityAndUnit.reference.unit
                 == esdl.UnitEnum.WATT
+                and parameters[f"{asset_name}.state"] == 2  # Optional asset
             ):
                 max_profile = max(self.get_timeseries(f"{asset_name}.maximum_heat_source").values)
                 if ub > max_profile:

--- a/tests/test_producer_profiles.py
+++ b/tests/test_producer_profiles.py
@@ -21,8 +21,8 @@ class TestProducerMaxProfile(TestCase):
 
     def test_max_producer_scaled_profile(self):
         """
-        Use a scaled profile, where there profile was intentionally reduced for a couple of
-        time-step (reducing the profile value at a few time steps). With the producer size not
+        Use a scaled profile, where the profile was intentionally reduced for a couple of
+        time-steps (reducing the profile value at a few time steps). With the producer size not
         being minimized.
 
         Checks:
@@ -64,7 +64,7 @@ class TestProducerMaxProfile(TestCase):
 
     def test_max_producer_esdl_unscaled_profile(self):
         """
-        Use a profile specified in Watts, where there profile was intentionally modified (via the
+        Use a profile specified in Watts, where the profile was intentionally modified (via the
         profile multiplier) such that it is smaller than the requried heating demand at a couple of
         timesteps. With the producer size being minimized.
 
@@ -139,8 +139,8 @@ class TestProducerMaxProfile(TestCase):
 
     def test_max_producer_esdl_scaled_profile(self):
         """
-        Use a scaled profile, where there profile was intentionally reduced for a couple of
-        time-step (reducing the profile value at a few time steps). With the producer size not
+        Use a scaled profile, where the profile was intentionally reduced for a couple of
+        time-steps (reducing the profile value at a few time steps). With the producer size not
         being minimized.
 
         Checks:

--- a/tests/test_producer_profiles.py
+++ b/tests/test_producer_profiles.py
@@ -104,15 +104,15 @@ class TestProducerMaxProfile(TestCase):
             heat_to_discharge_test(solution, results)
             tol = 1e-8
             heat_produced = results["HeatProducer_b702.Heat_source"]
-            heat_production_upper_limit = (
-                solution.get_timeseries("HeatProducer_b702.maximum_heat_source").values
-                / max(solution.get_timeseries("HeatProducer_b702.maximum_heat_source").values)
-                * results["HeatProducer_b702__max_size"]
-            )
 
             if problem_class == HeatProblemESDLProdProfile:
-                np.testing.assert_array_less(
-                    max(heat_production_upper_limit) - tol,
+                heat_production_upper_limit = solution.get_timeseries(
+                    "HeatProducer_b702.maximum_heat_source"
+                ).values
+                np.testing.assert_equal(
+                    solution.esdl_assets[
+                        solution.esdl_asset_name_to_id_map["HeatProducer_b702"]
+                    ].attributes["power"],
                     results["HeatProducer_b702__max_size"],
                 )
                 np.testing.assert_array_less(heat_produced - tol, heat_production_upper_limit)
@@ -121,6 +121,11 @@ class TestProducerMaxProfile(TestCase):
                     5,
                 )
             elif problem_class == HeatProblemESDLProdProfileTCO:
+                heat_production_upper_limit = (
+                    solution.get_timeseries("HeatProducer_b702.maximum_heat_source").values
+                    / max(solution.get_timeseries("HeatProducer_b702.maximum_heat_source").values)
+                    * results["HeatProducer_b702__max_size"]
+                )
                 np.testing.assert_allclose(
                     max(heat_production_upper_limit),
                     results["HeatProducer_b702__max_size"],


### PR DESCRIPTION
Now only updating the upper bound for the max_size variable when the asset is optional -->> 
parameters[f"{asset_name}.state"] == 2