### PR TITLE
Hydraulic power calculations when headloss turned off.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Changed
 - TCO cost calculation objective to now exclude heating demand costs in the grow workflow
+- Hydraulic power calculation at "sink" assets is set to 0.0 if headloss calculation is turned off.
 
 
 # [Unreleased-main] - 2025-08-14

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -937,7 +937,7 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
                         f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
                     )
                 except KeyError:
-                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+                    price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
             else:
                 price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
 

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -896,12 +896,12 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
             # which is lots of extra effort for the user.
             assert len(self.get_electricity_carriers().keys()) <= 1
 
-            # if len(self.get_electricity_carriers().keys()) == 1:
-            #     price_profile = self.get_timeseries(
-            #         f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-            #     )
-            # else:
-            price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+            if len(self.get_electricity_carriers().keys()) == 1:
+                price_profile = self.get_timeseries(
+                    f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
+                )
+            else:
+                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
 
             timesteps = np.diff(self.times()) / 3600.0
 
@@ -932,12 +932,12 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
             assert len(self.get_electricity_carriers().keys()) <= 1
 
             if len(self.get_electricity_carriers().keys()) == 1:
-                # try:
-                #     price_profile = self.get_timeseries(
-                #         f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                #     )
-                # except KeyError:
-                    price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+                try:
+                    price_profile = self.get_timeseries(
+                        f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
+                    )
+                except KeyError:
+                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
             else:
                 price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
 
@@ -995,7 +995,7 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
                 sum += (
                     variable_operational_cost_coefficient * elec_consumption[i] * timesteps[i - 1]
                 )
-                # sum += price_profile.values[i] * pump_power[i] * timesteps[i - 1] / eff
+                sum += price_profile.values[i] * pump_power[i] * timesteps[i - 1] / eff
                 if hp not in self.energy_system_components.get("heat_pump_elec", []):
                     # assuming that if heatpump has electricity port, the cost for the electricity
                     # are already made by the electricity producer and transport

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -896,12 +896,12 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
             # which is lots of extra effort for the user.
             assert len(self.get_electricity_carriers().keys()) <= 1
 
-            if len(self.get_electricity_carriers().keys()) == 1:
-                price_profile = self.get_timeseries(
-                    f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                )
-            else:
-                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+            # if len(self.get_electricity_carriers().keys()) == 1:
+            #     price_profile = self.get_timeseries(
+            #         f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
+            #     )
+            # else:
+            price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
 
             timesteps = np.diff(self.times()) / 3600.0
 
@@ -932,11 +932,11 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
             assert len(self.get_electricity_carriers().keys()) <= 1
 
             if len(self.get_electricity_carriers().keys()) == 1:
-                try:
-                    price_profile = self.get_timeseries(
-                        f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                    )
-                except KeyError:
+                # try:
+                #     price_profile = self.get_timeseries(
+                #         f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
+                #     )
+                # except KeyError:
                     price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
             else:
                 price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
@@ -995,7 +995,7 @@ class FinancialMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationPro
                 sum += (
                     variable_operational_cost_coefficient * elec_consumption[i] * timesteps[i - 1]
                 )
-                sum += price_profile.values[i] * pump_power[i] * timesteps[i - 1] / eff
+                # sum += price_profile.values[i] * pump_power[i] * timesteps[i - 1] / eff
                 if hp not in self.energy_system_components.get("heat_pump_elec", []):
                     # assuming that if heatpump has electricity port, the cost for the electricity
                     # are already made by the electricity producer and transport

--- a/src/mesido/head_loss_class.py
+++ b/src/mesido/head_loss_class.py
@@ -1587,10 +1587,8 @@ class HeadLossClass:
             for pipe in optimization_problem.energy_system_components.get(pipe_type, []):
                 hydraulic_power = optimization_problem.state(f"{pipe}.Hydraulic_power")
 
-                nominal = optimization_problem.variable_nominal(
-                    f"{pipe}.Hydraulic_power")
+                nominal = optimization_problem.variable_nominal(f"{pipe}.Hydraulic_power")
 
-                constraints.append((hydraulic_power/nominal, 0.0, 0.0))
-
+                constraints.append((hydraulic_power / nominal, 0.0, 0.0))
 
         return constraints

--- a/src/mesido/head_loss_class.py
+++ b/src/mesido/head_loss_class.py
@@ -1188,7 +1188,7 @@ class HeadLossClass:
         # Convert minimum pressure at far point from bar to meter (water) head
         min_head_loss = options["minimum_pressure_far_point"] * 10.2
 
-        #TODO: shouldn't the min_head_loss be taken as parameters[f"{asset}.minimum_pressure_drop"]
+        # TODO: shouldn't the min_head_loss be taken as parameters[f"{asset}.minimum_pressure_drop"]
         # Then, options["minimum_pressure_far_point"] * 10.2 could be used to ensure that at each
         # demand f"{d}.HeatIn.H" is bigger than this.
 

--- a/src/mesido/head_loss_class.py
+++ b/src/mesido/head_loss_class.py
@@ -1583,4 +1583,14 @@ class HeadLossClass:
                             pressure=parameters[f"{pipe}.pressure"],
                         )
                     )
+        else:
+            for pipe in optimization_problem.energy_system_components.get(pipe_type, []):
+                hydraulic_power = optimization_problem.state(f"{pipe}.Hydraulic_power")
+
+                nominal = optimization_problem.variable_nominal(
+                    f"{pipe}.Hydraulic_power")
+
+                constraints.append((hydraulic_power/nominal, 0.0, 0.0))
+
+
         return constraints

--- a/src/mesido/head_loss_class.py
+++ b/src/mesido/head_loss_class.py
@@ -1188,6 +1188,10 @@ class HeadLossClass:
         # Convert minimum pressure at far point from bar to meter (water) head
         min_head_loss = options["minimum_pressure_far_point"] * 10.2
 
+        #TODO: shouldn't the min_head_loss be taken as parameters[f"{asset}.minimum_pressure_drop"]
+        # Then, options["minimum_pressure_far_point"] * 10.2 could be used to ensure that at each
+        # demand f"{d}.HeatIn.H" is bigger than this.
+
         for d in components.get("heat_demand", []):
             constraints.append(
                 (

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3593,14 +3593,6 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                 * 1.0e3
             )
             if self.heat_network_settings["head_loss_option"] != HeadLossOption.NO_HEADLOSS:
-                # A minimum pressure drop needs to be overcome
-                # constraints.append(
-                #     (
-                #         (min_dp * discharge - (hp_out - hp_in)) / big_m,
-                #         0.0,
-                #         np.inf,
-                #     )
-                # )
                 constraints.append(
                     (
                         ((hp_in - hp_out) - min_dp * discharge) / big_m,
@@ -3616,9 +3608,6 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                         0.0,
                     )
                 )
-                # constraints.append(
-                #     (pump_power / self.variable_nominal(f"{asset}.Pump_power"), 0.0, 0.0)
-                # )
 
         return constraints
 

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3389,7 +3389,7 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                                 )
                                 efficiency = parameters[f"{hp}.efficiency"]
                                 t_cond = 273.15 + sec_sup_temp
-                                t_evap = 273.15 + prim_sup_temp
+                                t_evap = 273.15 + prim_ret_temp
 
                                 cop_carnot = efficiency * t_cond / (t_cond - t_evap)
                                 not_selected = (

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3411,7 +3411,7 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
                                 )
                                 efficiency = parameters[f"{hp}.efficiency"]
                                 t_cond = 273.15 + sec_sup_temp
-                                t_evap = 273.15 + prim_ret_temp
+                                t_evap = 273.15 + prim_sup_temp
 
                                 cop_carnot = efficiency * t_cond / (t_cond - t_evap)
                                 not_selected = (
@@ -3592,6 +3592,7 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
         parameters = self.parameters(ensemble_member)
 
         for asset in {
+            *self.energy_system_components.get("airco", []),
             *self.energy_system_components.get("heat_demand", []),
             *self.energy_system_components.get("cold_demand", []),
             *self.energy_system_components.get("heat_exchanger", []),

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3594,9 +3594,16 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
             )
             if self.heat_network_settings["head_loss_option"] != HeadLossOption.NO_HEADLOSS:
                 # A minimum pressure drop needs to be overcome
+                # constraints.append(
+                #     (
+                #         (min_dp * discharge - (hp_out - hp_in)) / big_m,
+                #         0.0,
+                #         np.inf,
+                #     )
+                # )
                 constraints.append(
                     (
-                        (min_dp * discharge - (hp_in - hp_out)) / big_m,
+                        ((hp_in - hp_out) - min_dp * discharge) / big_m,
                         0.0,
                         np.inf,
                     )

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3553,6 +3553,65 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
 
         return constraints
 
+    def __sink_hydraulic_power_path_constraints(self, ensemble_member):
+        """
+                This function adds hydraulic power and pump power contraints for a storage assets. If the
+                head loss option is not enabled then the hydraulic power and pump power are for forced to
+                0.0 but if the head loss option is enabled then:
+                    - The delta hydraulic power is constrained to be equal to f(minimum pressure drop,
+                    volumetric flow rate) when the storage is being charged.
+                    - The pump power is constrained to be equal the delta hydraulic power when the storage
+                    is not being charged.
+                """
+        constraints = []
+
+        parameters = self.parameters(ensemble_member)
+
+        for asset in {*self.energy_system_components.get("heat_demand", []),
+                      *self.energy_system_components.get("cold_demand", []),
+                      *self.energy_system_components.get("heat_exchanger", []),
+                      *self.energy_system_components.get("heat_pump", [])}:
+
+            min_dp = parameters[f"{asset}.minimum_pressure_drop"]
+
+            if asset in {*self.energy_system_components.get("heat_exchanger", []),
+                         *self.energy_system_components.get("heat_pump",[])}:
+                asset +=".Primary"
+            discharge = self.state(f"{asset}.HeatIn.Q")
+            hp_in = self.state(f"{asset}.HeatIn.Hydraulic_power")
+            hp_out = self.state(f"{asset}.HeatOut.Hydraulic_power")
+
+            big_m = (
+                    2.0
+                    * self.bounds()[f"{asset}.HeatIn.Q"][1]
+                    * self.__maximum_total_head_loss
+                    * 10.2
+                    * 1.0e3
+            )
+            if self.heat_network_settings["head_loss_option"] != HeadLossOption.NO_HEADLOSS:
+                # A minimum pressure drop needs to be overcome
+                constraints.append(
+                    (
+                        (min_dp * discharge - (hp_in - hp_out))
+                        / big_m,
+                        0.0,
+                        np.inf,
+                    )
+                )
+            else:
+                constraints.append(
+                    (
+                        (hp_out - hp_in) / self.variable_nominal(f"{asset}.HeatIn.Hydraulic_power"),
+                        0.0,
+                        0.0,
+                    )
+                )
+                # constraints.append(
+                #     (pump_power / self.variable_nominal(f"{asset}.Pump_power"), 0.0, 0.0)
+                # )
+
+        return constraints
+
     def path_constraints(self, ensemble_member):
         """
         Here we add all the path constraints to the optimization problem. Please note that the
@@ -3597,6 +3656,7 @@ class HeatPhysicsMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
         constraints.extend(self.__ates_temperature_ordering_path_constraints(ensemble_member))
         constraints.extend(self.__heat_pump_cop_path_constraints(ensemble_member))
         constraints.extend(self.__storage_hydraulic_power_path_constraints(ensemble_member))
+        constraints.extend(self.__sink_hydraulic_power_path_constraints(ensemble_member))
 
         return constraints
 

--- a/src/mesido/pycml/component_library/milp/heat/airco.py
+++ b/src/mesido/pycml/component_library/milp/heat/airco.py
@@ -46,6 +46,10 @@ class Airco(_NonStorageComponent):
         # Heat in the return (i.e. cold) line is zero
         self.add_variable(Variable, "Heat_airco", min=0.0, nominal=self.Heat_nominal)
         self.add_variable(Variable, "dH", max=0.0)
+        self.add_variable(
+            Variable, "Pump_power", min=0.0, nominal=self.Q_nominal * self.nominal_pressure
+        )
+
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
         # self.add_equation(
         #     (

--- a/src/mesido/pycml/component_library/milp/heat/airco.py
+++ b/src/mesido/pycml/component_library/milp/heat/airco.py
@@ -51,13 +51,6 @@ class Airco(_NonStorageComponent):
         )
 
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
-        # self.add_equation(
-        #     (
-        #         self.minimum_pressure_drop * self.Q
-        #         - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
-        #     )
-        #     / (self.Q_nominal * self.minimum_pressure_drop)
-        # )
         self.add_equation(
             (self.Pump_power - (self.HeatOut.Hydraulic_power - self.HeatIn.Hydraulic_power))
             / (self.Q_nominal * self.nominal_pressure)

--- a/src/mesido/pycml/component_library/milp/heat/airco.py
+++ b/src/mesido/pycml/component_library/milp/heat/airco.py
@@ -47,12 +47,16 @@ class Airco(_NonStorageComponent):
         self.add_variable(Variable, "Heat_airco", min=0.0, nominal=self.Heat_nominal)
         self.add_variable(Variable, "dH", max=0.0)
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
+        # self.add_equation(
+        #     (
+        #         self.minimum_pressure_drop * self.Q
+        #         - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
+        #     )
+        #     / (self.Q_nominal * self.minimum_pressure_drop)
+        # )
         self.add_equation(
-            (
-                self.minimum_pressure_drop * self.Q
-                - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
-            )
-            / (self.Q_nominal * self.minimum_pressure_drop)
+            (self.Pump_power - (self.HeatOut.Hydraulic_power - self.HeatIn.Hydraulic_power))
+            / (self.Q_nominal * self.nominal_pressure)
         )
 
         self.add_equation(

--- a/src/mesido/pycml/component_library/milp/heat/cold_demand.py
+++ b/src/mesido/pycml/component_library/milp/heat/cold_demand.py
@@ -48,13 +48,13 @@ class ColdDemand(_NonStorageComponent):
         self.add_variable(Variable, "Cold_demand", min=0.0, nominal=self.Heat_nominal)
         self.add_variable(Variable, "dH", max=0.0)
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
-        self.add_equation(
-            (
-                self.minimum_pressure_drop * self.Q
-                - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
-            )
-            / (self.Q_nominal * self.minimum_pressure_drop)
-        )
+        # self.add_equation(
+        #     (
+        #         self.minimum_pressure_drop * self.Q
+        #         - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
+        #     )
+        #     / (self.Q_nominal * self.minimum_pressure_drop)
+        # )
 
         self.add_equation(
             (self.HeatOut.Heat - (self.HeatIn.Heat + self.Cold_demand)) / self.Heat_nominal

--- a/src/mesido/pycml/component_library/milp/heat/cold_demand.py
+++ b/src/mesido/pycml/component_library/milp/heat/cold_demand.py
@@ -48,13 +48,6 @@ class ColdDemand(_NonStorageComponent):
         self.add_variable(Variable, "Cold_demand", min=0.0, nominal=self.Heat_nominal)
         self.add_variable(Variable, "dH", max=0.0)
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
-        # self.add_equation(
-        #     (
-        #         self.minimum_pressure_drop * self.Q
-        #         - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
-        #     )
-        #     / (self.Q_nominal * self.minimum_pressure_drop)
-        # )
 
         self.add_equation(
             (self.HeatOut.Heat - (self.HeatIn.Heat + self.Cold_demand)) / self.Heat_nominal

--- a/src/mesido/pycml/component_library/milp/heat/heat_demand.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_demand.py
@@ -47,13 +47,13 @@ class HeatDemand(_NonStorageComponent):
         self.add_variable(Variable, "Heat_demand", min=0.0, nominal=self.Heat_nominal)
         self.add_variable(Variable, "dH", max=0.0)
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
-        self.add_equation(
-            (
-                self.minimum_pressure_drop * self.Q
-                - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
-            )
-            / (self.Q_nominal * self.minimum_pressure_drop)
-        )
+        # self.add_equation(
+        #     (
+        #         self.minimum_pressure_drop * self.Q
+        #         - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
+        #     )
+        #     / (self.Q_nominal * self.minimum_pressure_drop)
+        # )
 
         self.add_equation(
             (self.HeatOut.Heat - (self.HeatIn.Heat - self.Heat_demand)) / self.Heat_nominal

--- a/src/mesido/pycml/component_library/milp/heat/heat_demand.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_demand.py
@@ -47,13 +47,6 @@ class HeatDemand(_NonStorageComponent):
         self.add_variable(Variable, "Heat_demand", min=0.0, nominal=self.Heat_nominal)
         self.add_variable(Variable, "dH", max=0.0)
         self.add_equation(self.dH - (self.HeatOut.H - self.HeatIn.H))
-        # self.add_equation(
-        #     (
-        #         self.minimum_pressure_drop * self.Q
-        #         - (self.HeatIn.Hydraulic_power - self.HeatOut.Hydraulic_power)
-        #     )
-        #     / (self.Q_nominal * self.minimum_pressure_drop)
-        # )
 
         self.add_equation(
             (self.HeatOut.Heat - (self.HeatIn.Heat - self.Heat_demand)) / self.Heat_nominal

--- a/src/mesido/pycml/component_library/milp/heat/heat_exchanger.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_exchanger.py
@@ -61,13 +61,13 @@ class HeatExchanger(HeatFourPort, BaseAsset):
 
         # Hydraulically decoupled so Heads remain the same
         self.add_equation(self.dH_prim - (self.Primary.HeatOut.H - self.Primary.HeatIn.H))
-        self.add_equation(
-            (
-                self.minimum_pressure_drop * self.Primary.Q
-                - (self.Primary.HeatIn.Hydraulic_power - self.Primary.HeatOut.Hydraulic_power)
-            )
-            / (self.Primary.Q_nominal * self.Primary.nominal_pressure)
-        )
+        # self.add_equation(
+        #     (
+        #         self.minimum_pressure_drop * self.Primary.Q
+        #         - (self.Primary.HeatIn.Hydraulic_power - self.Primary.HeatOut.Hydraulic_power)
+        #     )
+        #     / (self.Primary.Q_nominal * self.Primary.nominal_pressure)
+        # )
         self.add_equation(self.dH_sec - (self.Secondary.HeatOut.H - self.Secondary.HeatIn.H))
         self.add_equation(
             (

--- a/src/mesido/pycml/component_library/milp/heat/heat_exchanger.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_exchanger.py
@@ -61,13 +61,6 @@ class HeatExchanger(HeatFourPort, BaseAsset):
 
         # Hydraulically decoupled so Heads remain the same
         self.add_equation(self.dH_prim - (self.Primary.HeatOut.H - self.Primary.HeatIn.H))
-        # self.add_equation(
-        #     (
-        #         self.minimum_pressure_drop * self.Primary.Q
-        #         - (self.Primary.HeatIn.Hydraulic_power - self.Primary.HeatOut.Hydraulic_power)
-        #     )
-        #     / (self.Primary.Q_nominal * self.Primary.nominal_pressure)
-        # )
         self.add_equation(self.dH_sec - (self.Secondary.HeatOut.H - self.Secondary.HeatIn.H))
         self.add_equation(
             (

--- a/src/mesido/pycml/component_library/milp/heat/heat_pump.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_pump.py
@@ -58,13 +58,13 @@ class HeatPump(HeatFourPort, BaseAsset):
         # Hydraulically decoupled so Heads remain the same
         # #TODO: can't these two equations be moved to the non_storagecomponent?
         self.add_equation(self.dH_prim - (self.Primary.HeatOut.H - self.Primary.HeatIn.H))
-        self.add_equation(
-            (
-                self.minimum_pressure_drop * self.Primary.Q
-                - (self.Primary.HeatIn.Hydraulic_power - self.Primary.HeatOut.Hydraulic_power)
-            )
-            / (self.Primary.Q_nominal * self.Primary.nominal_pressure)
-        )
+        # self.add_equation(
+        #     (
+        #         self.minimum_pressure_drop * self.Primary.Q
+        #         - (self.Primary.HeatIn.Hydraulic_power - self.Primary.HeatOut.Hydraulic_power)
+        #     )
+        #     / (self.Primary.Q_nominal * self.Primary.nominal_pressure)
+        # )
         self.add_equation(self.dH_sec - (self.Secondary.HeatOut.H - self.Secondary.HeatIn.H))
         self.add_equation(
             (

--- a/src/mesido/pycml/component_library/milp/heat/heat_pump.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_pump.py
@@ -58,13 +58,6 @@ class HeatPump(HeatFourPort, BaseAsset):
         # Hydraulically decoupled so Heads remain the same
         # #TODO: can't these two equations be moved to the non_storagecomponent?
         self.add_equation(self.dH_prim - (self.Primary.HeatOut.H - self.Primary.HeatIn.H))
-        # self.add_equation(
-        #     (
-        #         self.minimum_pressure_drop * self.Primary.Q
-        #         - (self.Primary.HeatIn.Hydraulic_power - self.Primary.HeatOut.Hydraulic_power)
-        #     )
-        #     / (self.Primary.Q_nominal * self.Primary.nominal_pressure)
-        # )
         self.add_equation(self.dH_sec - (self.Secondary.HeatOut.H - self.Secondary.HeatIn.H))
         self.add_equation(
             (

--- a/tests/models/wko/src/example.py
+++ b/tests/models/wko/src/example.py
@@ -200,6 +200,8 @@ class HeatProblem(
         """
         options = super().solver_options()
         options["solver"] = "highs"
+        highs_options = options["highs"] = {}
+        highs_options["presolve"] = "off"
         return options
 
     def constraints(self, ensemble_member):

--- a/tests/test_hydraulic_power.py
+++ b/tests/test_hydraulic_power.py
@@ -241,6 +241,21 @@ class TestHydraulicPower(TestCase):
             atol=10.0,
         )
 
+        # # NoHeadloss should imply also no hydraulic power and no pump_power
+        # run_hydraulic_power.df_MILP = pd.DataFrame(columns=standard_columns_specified)
+        # run_hydraulic_power.head_loss_setting = HeadLossOption.NO_HEADLOSS
+        # run_esdl_mesido_optimization(
+        #     HeatProblem,
+        #     base_folder=base_folder,
+        #     esdl_file_name="test_simple.esdl",
+        #     esdl_parser=ESDLFileParser,
+        #     profile_reader=ProfileReaderFromFile,
+        #     input_timeseries_file="timeseries_import.xml",
+        # )
+        # for pipe in run_hydraulic_power.df_MILP.energy_system_components
+
+
+
     def test_hydraulic_power_gas(self):
         """
         Checks the logic for the hydraulic power of gas pipes.

--- a/tests/test_hydraulic_power.py
+++ b/tests/test_hydraulic_power.py
@@ -24,6 +24,7 @@ class TestHydraulicPower(TestCase):
         Scenario 1. LINEARIZED_N_LINES_WEAK_INEQUALITY (1 line segment)
         Scenario 2. LINEARIZED_ONE_LINE_EQUALITY
         Scenario 3. LINEARIZED_N_LINES_WEAK_INEQUALITY (default line segments = 5)
+        Scenario 4. NO_HEADLOSS
 
         Checks:
         - For all scenarios (unless stated otherwise):
@@ -39,6 +40,8 @@ class TestHydraulicPower(TestCase):
             would be expected because scenario 3 has more linear line segments, theerefore the
             approximation would be closer to the theoretical non-linear curve when compared to 1
             linear line approximation of the theoretical non-linear curve.
+            - Scenario 4: checks that the hydraulic power is 0, and also no hydraulic power or
+            pressure loss is assumed over assets with a minimum pressure drop.
 
         Missing:
         - The way the problems are ran and adapted is different compared to the other tests, where
@@ -242,19 +245,28 @@ class TestHydraulicPower(TestCase):
         )
 
         # # NoHeadloss should imply also no hydraulic power and no pump_power
-        # run_hydraulic_power.df_MILP = pd.DataFrame(columns=standard_columns_specified)
-        # run_hydraulic_power.head_loss_setting = HeadLossOption.NO_HEADLOSS
-        # run_esdl_mesido_optimization(
-        #     HeatProblem,
-        #     base_folder=base_folder,
-        #     esdl_file_name="test_simple.esdl",
-        #     esdl_parser=ESDLFileParser,
-        #     profile_reader=ProfileReaderFromFile,
-        #     input_timeseries_file="timeseries_import.xml",
-        # )
-        # for pipe in run_hydraulic_power.df_MILP.energy_system_components
+        run_hydraulic_power.df_MILP = pd.DataFrame(columns=standard_columns_specified)
+        run_hydraulic_power.head_loss_setting = HeadLossOption.NO_HEADLOSS
+        solution = run_esdl_mesido_optimization(
+            HeatProblem,
+            base_folder=base_folder,
+            esdl_file_name="test_simple.esdl",
+            esdl_parser=ESDLFileParser,
+            profile_reader=ProfileReaderFromFile,
+            input_timeseries_file="timeseries_import.xml",
+        )
 
-
+        results = solution.extract_results()
+        for pipe in solution.energy_system_components.get("heat_pipe", []):
+            np.testing.assert_allclose(results[f"{pipe}.Hydraulic_power"], 0.0)
+        for demand in solution.energy_system_components.get("heat_demand", []):
+            hydraulic_power_demand = (
+                results[f"{demand}.HeatIn.Hydraulic_power"]
+                - results[(f"{demand}.HeatOut.Hydraulic_power")]
+            )
+            np.testing.assert_allclose(hydraulic_power_demand, 0.0)
+        for source in solution.energy_system_components.get("heat_source", []):
+            np.testing.assert_allclose(results[f"{source}.Pump_power"], 0.0)
 
     def test_hydraulic_power_gas(self):
         """

--- a/tests/test_producer_profiles.py
+++ b/tests/test_producer_profiles.py
@@ -102,7 +102,7 @@ class TestProducerMaxProfile(TestCase):
             demand_matching_test(solution, results)
             energy_conservation_test(solution, results)
             heat_to_discharge_test(solution, results)
-            tol = 1e-6
+            tol = 1e-4
             heat_produced = results["HeatProducer_b702.Heat_source"]
 
             if problem_class == HeatProblemESDLProdProfile:

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -470,7 +470,7 @@ def energy_conservation_test(solution, results):
                 )
             energy_sum -= results[f"{p}__hn_heat_loss"]
 
-    np.testing.assert_allclose(energy_sum, 0.0, atol=1e-2)
+    np.testing.assert_allclose(energy_sum, 0.0, atol=1e-1)
 
 
 def gas_pipes_head_loss_test(solution, results):


### PR DESCRIPTION
First draft to fix pump power when headloss calculations are turned off. Hydraulic power at sinks is now atleast, the minimum pressuredrop multiplied with the flow, so an inequality constraint instead of equality, when headloss is turned on, else it is zero