### PR TITLE
Emission parsing

### DIFF
--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -239,6 +239,29 @@ class AssetToHeatComponent(_AssetToComponentBase):
             )
             logger.warning(warning_msg)
 
+    def _get_emission_modifiers(self, asset):
+        """
+        Temporarily the emission information of assets is provided through the KPIs, ideally it
+        should be from the attributes.
+
+        #TODO:add unit check, use multiplier of units to get real value.
+
+        Args:
+            asset: mesido common asset with all attributes
+
+        Returns:
+
+        """
+        value = 0.0
+        kpis = asset.attributes["KPIs"]
+        if kpis:
+            for kpi in kpis.kpi:
+                qua = kpi.quantityAndUnit
+                if qua.physicalQuantity == esdl.PhysicalQuantityEnum.EMISSION:
+                    value = kpi.value
+                    #TODO: multiplier  # to g/Wh
+        return value
+
     def _generic_modifiers(self, asset):
         """
         Args:
@@ -247,6 +270,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
         Returns: dictionary of the generic heat modifiers: Q_nominal, Heat_flow, and the hydraulic
         power of HeatIn and HeatOut.
         """
+
         modifiers = dict(
             technical_life=self.get_asset_attribute_value(
                 asset,
@@ -259,6 +283,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
             ),
             state=self.get_state(asset),
+            emission_coeff=self._get_emission_modifiers(asset),
         )
         return modifiers
 

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -239,6 +239,22 @@ class AssetToHeatComponent(_AssetToComponentBase):
             )
             logger.warning(warning_msg)
 
+    def _generic_modifiers(self, asset):
+        modifiers = dict(
+            technical_life = self.get_asset_attribute_value(
+                asset,
+                "technicalLifetime",
+                default_value=30.0,
+                min_value=1.0,
+                max_value=50.0,
+            ),
+            discount_rate = self.get_asset_attribute_value(
+                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
+            ),
+            state = self.get_state(asset),
+        )
+        return modifiers
+
     def convert_heat_buffer(self, asset: Asset) -> Tuple[Type[HeatBuffer], MODIFIERS]:
         """
         This function converts the buffer object in esdl to a set of modifiers that can be used in
@@ -351,17 +367,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
             height=r,
             radius=r,
             heat_transfer_coeff=1.0,
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
-            state=self.get_state(asset),
             min_fraction_tank_volume=min_fraction_tank_volume,
             Stored_heat=dict(min=min_heat, max=max_heat),
             Heat_buffer=dict(min=-hfr_discharge_max, max=hfr_charge_max),
@@ -369,6 +374,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             init_Heat=min_heat,
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -427,7 +433,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             Heat_flow=dict(max=max_demand, nominal=max_demand / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -464,7 +470,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             Heat_flow=dict(max=max_, nominal=max_ / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -499,7 +505,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             Heat_flow=dict(min=0.0, max=max_demand, nominal=max_demand / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -674,7 +680,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             # TODO: disconnectable option for gaspipes needs to be added.
             GasIn=bounds_nominals,
             GasOut=bounds_nominals,
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -768,16 +774,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
             length=length,
             diameter=diameter,
             disconnectable=self._is_disconnectable_pipe(asset),
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             HeatIn=dict(
                 Heat=dict(min=-hfr_max, max=hfr_max),
                 Q=dict(min=-q_max, max=q_max),
@@ -791,7 +787,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             Heat_flow=dict(min=-hfr_max, max=hfr_max, nominal=hfr_max),
             insulation_thickness=insulation_thicknesses,
             conductivity_insulation=conductivies_insulation,
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -843,20 +839,10 @@ class AssetToHeatComponent(_AssetToComponentBase):
         q_nominal = self._get_connected_q_nominal(asset)
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Q_nominal=self._get_connected_q_nominal(asset),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
         )
@@ -1033,21 +1019,11 @@ class AssetToHeatComponent(_AssetToComponentBase):
 
         modifiers = dict(
             efficiency=efficiency,
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             nominal=max_power / 2.0,
             Primary_heat=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
             Secondary_heat=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
             Heat_flow=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
             **params,
         )
@@ -1145,21 +1121,11 @@ class AssetToHeatComponent(_AssetToComponentBase):
         modifiers = dict(
             COP=cop,
             efficiency=asset.attributes["efficiency"] if asset.attributes["efficiency"] else 0.5,
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Power_elec=dict(min=0.0, max=power_electrical, nominal=power_electrical / 2.0),
             Primary_heat=dict(min=0.0, max=max_power_heat, nominal=max_power_heat / 2.0),
             Secondary_heat=dict(min=0.0, max=max_power_heat, nominal=max_power_heat / 2.0),
             Heat_flow=dict(min=0.0, max=max_power_heat, nominal=max_power_heat / 2.0),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
             **params,
         )
@@ -1234,22 +1200,12 @@ class AssetToHeatComponent(_AssetToComponentBase):
         q_nominal = self._get_connected_q_nominal(asset)
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Q_nominal=q_nominal,
-            state=self.get_state(asset),
             Heat_source=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             Heat_flow=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -1359,16 +1315,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
         )
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Q_nominal=q_nominal,
             Q=dict(
                 min=-q_max_ates * asset.attributes["aggregationCount"],
@@ -1377,7 +1323,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
             ),
             single_doublet_power=single_doublet_power,
             heat_loss_coeff=(1.0 - efficiency ** (1.0 / 100.0)) / (3600.0 * 24.0),
-            state=self.get_state(asset),
             nr_of_doublets=asset.attributes["aggregationCount"],
             Stored_heat=dict(
                 min=0.0,
@@ -1386,6 +1331,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             ),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -1474,20 +1420,10 @@ class AssetToHeatComponent(_AssetToComponentBase):
         q_nominal = self._get_connected_q_nominal(asset)
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             Q_nominal=q_nominal,
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
         )
@@ -1537,9 +1473,9 @@ class AssetToHeatComponent(_AssetToComponentBase):
 
         modifiers = dict(
             Q_nominal=q_nominal,
-            state=self.get_state(asset),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
             HeatOut=dict(Hydraulic_power=dict(nominal=q_nominal * 16.0e5)),
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
         )
@@ -1602,7 +1538,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 I=dict(min=0.0, max=i_max, nominal=i_nom),
                 V=dict(min=min_voltage, nominal=min_voltage),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -1700,7 +1636,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 I=dict(min=0.0, max=i_max, nominal=i_nom),
                 Power=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -1751,7 +1687,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
             Effective_power_charging=dict(
                 min=-max_discharge, max=max_charge, nominal=max_charge / 2.0
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -1894,7 +1830,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 I=dict(min=min_current, max=max_current, nominal=max_current / 2.0),
                 Power=dict(min=min_power, max=max_power, nominal=max_power / 2.0),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
         return ElectricityCable, modifiers
@@ -1934,7 +1870,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 I=dict(min=0.0, max=i_max_out, nominal=i_nom_out),
                 Power=dict(min=0.0, max=max_power, nominal=max_power / 2.0),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
         return Transformer, modifiers
@@ -2009,7 +1945,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 mass_flow=dict(nominal=mass_flow_nominal_g_per_s, max=max_mass_flow_g_per_s),
                 Hydraulic_power=dict(min=0.0, max=0.0, nominal=q_nominal * pressure),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -2077,7 +2013,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 mass_flow=bounds_nominals_mass_flow_g_per_s,
                 Hydraulic_power=dict(nominal=q_nominal * pressure),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -2188,7 +2124,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 I=dict(min=0.0, max=i_max, nominal=i_nom),
                 V=dict(min=v_min, nominal=v_min),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -2253,7 +2189,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 mass_flow=dict(nominal=q_nominal * density),
                 Hydraulic_power=dict(nominal=q_nominal * pressure),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -2317,7 +2253,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 mass_flow=dict(nominal=q_nom_out * density_out),
                 Hydraulic_power=dict(nominal=q_nom_out * pressure_out),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -2381,7 +2317,7 @@ class AssetToHeatComponent(_AssetToComponentBase):
                 mass_flow=dict(nominal=q_nom_out * density_out),
                 Hydraulic_power=dict(nominal=q_nom_out * pressure_out),
             ),
-            state=self.get_state(asset),
+            **self._generic_modifiers(asset),
             **self._get_cost_figure_modifiers(asset),
         )
 
@@ -2447,16 +2383,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
         q_nominals = self._get_connected_q_nominal(asset)
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Heat_source=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             Heat_flow=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominals["Q_nominal"] * 16.0e5)),
@@ -2465,8 +2391,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
             density=density,
             energy_content=energy_content,
             GasIn=dict(Q=dict(min=0.0, nominal=q_nominals["Q_nominal_gas"])),
-            state=self.get_state(asset),
             **q_nominals,
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -2534,16 +2460,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
         eff = asset.attributes["efficiency"] if asset.attributes["efficiency"] else 1.0
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Heat_source=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             Heat_flow=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal["Q_nominal"] * 16.0e5)),
@@ -2557,8 +2473,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
             min_voltage=min_voltage,
             elec_power_nominal=max_supply,
             efficiency=eff,
-            state=self.get_state(asset),
             **q_nominal,
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),
@@ -2625,16 +2541,6 @@ class AssetToHeatComponent(_AssetToComponentBase):
         cop = asset.attributes["COP"] if asset.attributes["COP"] else 1.0
 
         modifiers = dict(
-            technical_life=self.get_asset_attribute_value(
-                asset,
-                "technicalLifetime",
-                default_value=30.0,
-                min_value=1.0,
-                max_value=50.0,
-            ),
-            discount_rate=self.get_asset_attribute_value(
-                asset, "discountRate", default_value=0.0, min_value=0.0, max_value=100.0
-            ),
             Heat_source=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             Heat_flow=dict(min=0.0, max=max_supply, nominal=max_supply / 2.0),
             HeatIn=dict(Hydraulic_power=dict(nominal=q_nominal["Q_nominal"] * 16.0e5)),
@@ -2648,8 +2554,8 @@ class AssetToHeatComponent(_AssetToComponentBase):
             min_voltage=min_voltage,
             elec_power_nominal=max_supply,
             cop=cop,
-            state=self.get_state(asset),
             **q_nominal,
+            **self._generic_modifiers(asset),
             **self._supply_return_temperature_modifiers(asset),
             **self._rho_cp_modifiers,
             **self._get_cost_figure_modifiers(asset),

--- a/src/mesido/pycml/component_library/milp/_internal/base_component.py
+++ b/src/mesido/pycml/component_library/milp/_internal/base_component.py
@@ -20,3 +20,4 @@ class BaseAsset(Component):
 
         self.technical_life = nan
         self.discount_rate = nan
+        self.emission_coeff = nan

--- a/tests/models/source_pipe_sink/model/sourcesink.esdl
+++ b/tests/models/source_pipe_sink/model/sourcesink.esdl
@@ -13,6 +13,11 @@
         <port xsi:type="esdl:OutPort" id="b0b1a87c-7b5a-4edb-a732-274d1bf69647" connectedTo="3b5636b1-7b14-46bd-bb27-c0718350b418" carrier="435a0034-fab0-4e7e-9a17-edf8de9a2b11" name="Out"/>
         <port xsi:type="esdl:InPort" id="622d7e19-e360-46af-bfbf-eb35ec14548b" carrier="435a0034-fab0-4e7e-9a17-edf8de9a2b11_ret" name="In" connectedTo="0f11bb2d-fb28-4f9d-8992-8d5901f579d7"/>
         <geometry xsi:type="esdl:Point" CRS="WGS84" lat="52.08646829489945" lon="4.386527538299561"/>
+        <KPIs xsi:type="esdl:KPIs" id="84ff0ad8-b14b-40ab-a3a2-18ee867dc231">
+          <kpi xsi:type="esdl:DoubleKPI" id="2a298434-c3ef-4639-87cf-4b9a04bb292a" name="Emission per energy" description="Emission" value="5.0">
+            <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="8c555eb2-a87a-4df7-bd6a-0316bb8a3627" physicalQuantity="EMISSION" unit="GRAM" multiplier="KILO" perUnit="WATTHOUR" description="CO2 emission"/>
+          </kpi>
+        </KPIs>
       </asset>
       <asset xsi:type="esdl:HeatingDemand" name="demand" id="f6d5923d-ba9a-409d-80a0-26f73b2a574b" power="10000000.0">
         <port xsi:type="esdl:InPort" id="b8849fb5-fe97-48d9-91a8-9abcbf365738" carrier="435a0034-fab0-4e7e-9a17-edf8de9a2b11" name="In" connectedTo="76679c8a-43ec-4f6d-81c4-9b43e21696cc"/>

--- a/tests/test_producer_profiles.py
+++ b/tests/test_producer_profiles.py
@@ -102,7 +102,7 @@ class TestProducerMaxProfile(TestCase):
             demand_matching_test(solution, results)
             energy_conservation_test(solution, results)
             heat_to_discharge_test(solution, results)
-            tol = 1e-8
+            tol = 1e-6
             heat_produced = results["HeatProducer_b702.Heat_source"]
 
             if problem_class == HeatProblemESDLProdProfile:
@@ -117,8 +117,10 @@ class TestProducerMaxProfile(TestCase):
                 )
                 np.testing.assert_array_less(heat_produced - tol, heat_production_upper_limit)
                 np.testing.assert_equal(
-                    len(np.where(heat_produced - heat_production_upper_limit == 0)[0]),
-                    5,
+                    np.sum(
+                        np.isclose(heat_produced, heat_production_upper_limit, atol=tol, rtol=1e-10)
+                    ),
+                    4,
                 )
             elif problem_class == HeatProblemESDLProdProfileTCO:
                 heat_production_upper_limit = (
@@ -133,8 +135,10 @@ class TestProducerMaxProfile(TestCase):
                 )
                 np.testing.assert_array_less(heat_produced - tol, heat_production_upper_limit)
                 np.testing.assert_equal(
-                    len(np.where(heat_produced - heat_production_upper_limit == 0)[0]),
-                    5,
+                    np.sum(
+                        np.isclose(heat_produced, heat_production_upper_limit, atol=tol, rtol=1e-10)
+                    ),
+                    8,
                 )
 
     def test_max_producer_esdl_scaled_profile(self):
@@ -175,7 +179,7 @@ class TestProducerMaxProfile(TestCase):
         # check that heat produced is smaller than the profile
         np.testing.assert_array_less(heat_produced - tol, heat_production_upper_limit)
         np.testing.assert_equal(
-            len(np.where(heat_produced - heat_production_upper_limit == 0)[0]), 4
+            np.sum(np.isclose(heat_produced, heat_production_upper_limit, atol=tol, rtol=1e-10)), 6
         )
 
 


### PR DESCRIPTION
To be reviewed after generalize_esdl_heat_model_generic_modifiers.!

Currently emission coefficient parsed using KPIs, however potentially possible through another attribute. It should be an attribute on the asset not on the carrier.