### PR TITLE
Fix import order

### DIFF
--- a/src/mesido/_darcy_weisbach.py
+++ b/src/mesido/_darcy_weisbach.py
@@ -1,11 +1,10 @@
 import math
 
 import CoolProp as cP
+import numpy as np
 
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.network_common import NetworkSettings
-
-import numpy as np
 
 
 def _kinematic_viscosity(temperature, network_type=NetworkSettings.NETWORK_TYPE_HEAT, pressure=0.0):

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -3,8 +3,11 @@ import sys
 from typing import List, Set
 
 import casadi as ca
-
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.timeseries import Timeseries
 
 from mesido._heat_loss_u_values_pipe import pipe_heat_loss
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
@@ -13,13 +16,6 @@ from mesido.esdl.asset_to_component_base import AssetStateEnum
 from mesido.head_loss_class import HeadLossOption
 from mesido.network_common import NetworkSettings
 from mesido.pipe_class import CableClass, GasPipeClass, PipeClass
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.timeseries import Timeseries
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/component_type_mixin.py
+++ b/src/mesido/component_type_mixin.py
@@ -1,14 +1,13 @@
 import logging
 from typing import Dict, Set
 
+import numpy as np
+from pymoca.backends.casadi.alias_relation import AliasRelation
+
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.heat_network_common import NodeConnectionDirection
 from mesido.network_common import NetworkSettings
 from mesido.topology import Topology
-
-import numpy as np
-
-from pymoca.backends.casadi.alias_relation import AliasRelation
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/electricity_physics_mixin.py
+++ b/src/mesido/electricity_physics_mixin.py
@@ -5,16 +5,12 @@ from math import isclose
 from typing import List, Tuple
 
 import casadi as ca
-
-from mesido.base_component_type_mixin import BaseComponentTypeMixin
-
 import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
 from rtctools.optimization.timeseries import Timeseries
 
+from mesido.base_component_type_mixin import BaseComponentTypeMixin
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/esdl/_update_edr_pipes_json.py
+++ b/src/mesido/esdl/_update_edr_pipes_json.py
@@ -2,9 +2,9 @@ import json
 import xml.etree.ElementTree as ET  # noqa: N817
 from typing import Tuple
 
-from mesido._heat_loss_u_values_pipe import heat_loss_u_values_pipe
-
 import requests
+
+from mesido._heat_loss_u_values_pipe import heat_loss_u_values_pipe
 
 
 def main():

--- a/src/mesido/esdl/asset_to_component_base.py
+++ b/src/mesido/esdl/asset_to_component_base.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, Type, Union
 
 import CoolProp as cP
-
 import esdl
 from esdl import TimeUnitEnum, UnitEnum
 
@@ -16,7 +15,6 @@ from mesido.esdl.common import Asset
 from mesido.network_common import NetworkSettings
 from mesido.potential_errors import MesidoAssetIssueType, get_potential_errors
 from mesido.pycml import Model as _Model
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/esdl/esdl_additional_vars_mixin.py
+++ b/src/mesido/esdl/esdl_additional_vars_mixin.py
@@ -2,15 +2,12 @@ import logging
 from typing import List
 
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
 
 from mesido.network_common import NetworkSettings
 from mesido.pipe_class import PipeClass
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/esdl/esdl_heat_model.py
+++ b/src/mesido/esdl/esdl_heat_model.py
@@ -5,56 +5,35 @@ import math
 from typing import Dict, Tuple, Type, Union
 
 import esdl
+from scipy.optimize import fsolve
 
-from mesido.esdl.asset_to_component_base import (
-    MODIFIERS,
-    _AssetToComponentBase,
-    get_density,
-    get_energy_content,
-)
+from mesido.esdl.asset_to_component_base import (MODIFIERS,
+                                                 _AssetToComponentBase,
+                                                 get_density,
+                                                 get_energy_content)
 from mesido.esdl.common import Asset
 from mesido.esdl.esdl_model_base import _ESDLModelBase
 from mesido.potential_errors import MesidoAssetIssueType, get_potential_errors
-from mesido.pycml.component_library.milp import (
-    ATES,
-    AirWaterHeatPump,
-    AirWaterHeatPumpElec,
-    Airco,
-    CheckValve,
-    ColdDemand,
-    Compressor,
-    ControlValve,
-    ElecBoiler,
-    ElectricityCable,
-    ElectricityDemand,
-    ElectricityNode,
-    ElectricitySource,
-    ElectricityStorage,
-    Electrolyzer,
-    GasBoiler,
-    GasDemand,
-    GasNode,
-    GasPipe,
-    GasSource,
-    GasSubstation,
-    GasTankStorage,
-    GeothermalSource,
-    HeatBuffer,
-    HeatDemand,
-    HeatExchanger,
-    HeatPipe,
-    HeatPump,
-    HeatPumpElec,
-    HeatSource,
-    LowTemperatureATES,
-    Node,
-    Pump,
-    SolarPV,
-    Transformer,
-    WindPark,
-)
-
-from scipy.optimize import fsolve
+from mesido.pycml.component_library.milp import (ATES, Airco, AirWaterHeatPump,
+                                                 AirWaterHeatPumpElec,
+                                                 CheckValve, ColdDemand,
+                                                 Compressor, ControlValve,
+                                                 ElecBoiler, ElectricityCable,
+                                                 ElectricityDemand,
+                                                 ElectricityNode,
+                                                 ElectricitySource,
+                                                 ElectricityStorage,
+                                                 Electrolyzer, GasBoiler,
+                                                 GasDemand, GasNode, GasPipe,
+                                                 GasSource, GasSubstation,
+                                                 GasTankStorage,
+                                                 GeothermalSource, HeatBuffer,
+                                                 HeatDemand, HeatExchanger,
+                                                 HeatPipe, HeatPump,
+                                                 HeatPumpElec, HeatSource,
+                                                 LowTemperatureATES, Node,
+                                                 Pump, SolarPV, Transformer,
+                                                 WindPark)
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/esdl/esdl_mixin.py
+++ b/src/mesido/esdl/esdl_mixin.py
@@ -8,10 +8,13 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import esdl.esdl_handler
+import numpy as np
+import rtctools.data.pi as pi
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.io_mixin import IOMixin
 
-from mesido.component_type_mixin import (
-    ModelicaComponentTypeMixin,
-)
+from mesido.component_type_mixin import ModelicaComponentTypeMixin
 from mesido.esdl.asset_to_component_base import _AssetToComponentBase
 from mesido.esdl.common import Asset
 from mesido.esdl.edr_pipe_class import EDRGasPipeClass, EDRPipeClass
@@ -24,15 +27,6 @@ from mesido.physics_mixin import PhysicsMixin
 from mesido.pipe_class import GasPipeClass, PipeClass
 from mesido.pycml.pycml_mixin import PyCMLMixin
 from mesido.qth_not_maintained.qth_mixin import QTHMixin
-
-import numpy as np
-
-import rtctools.data.pi as pi
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.io_mixin import IOMixin
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/esdl/esdl_qth_model.py
+++ b/src/mesido/esdl/esdl_qth_model.py
@@ -4,21 +4,15 @@ from typing import Dict, Tuple, Type
 
 import esdl
 
-from mesido.esdl.asset_to_component_base import MODIFIERS, _AssetToComponentBase
+from mesido.esdl.asset_to_component_base import (MODIFIERS,
+                                                 _AssetToComponentBase)
 from mesido.esdl.common import Asset
 from mesido.esdl.esdl_model_base import _ESDLModelBase
 from mesido.pycml import SymbolicParameter
-from mesido.pycml.component_library.qth import (
-    Buffer,
-    CheckValve,
-    ControlValve,
-    Demand,
-    GeothermalSource,
-    Node,
-    Pipe,
-    Pump,
-    Source,
-)
+from mesido.pycml.component_library.qth import (Buffer, CheckValve,
+                                                ControlValve, Demand,
+                                                GeothermalSource, Node, Pipe,
+                                                Pump, Source)
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/esdl/profile_parser.py
+++ b/src/mesido/esdl/profile_parser.py
@@ -6,20 +6,16 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 
 import esdl
-from esdl.profiles.influxdbprofilemanager import ConnectionSettings
-from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
+import numpy as np
+import pandas as pd
+import rtctools.data.pi
+from esdl.profiles.influxdbprofilemanager import (ConnectionSettings,
+                                                  InfluxDBProfileManager)
 from esdl.units.conversion import ENERGY_IN_J, POWER_IN_W, convert_to_unit
+from rtctools.data.storage import DataStore
 
 from mesido.esdl.common import Asset
 from mesido.potential_errors import MesidoAssetIssueType, get_potential_errors
-
-import numpy as np
-
-import pandas as pd
-
-import rtctools.data.pi
-from rtctools.data.storage import DataStore
-
 
 logger = logging.getLogger()
 

--- a/src/mesido/exceptions.py
+++ b/src/mesido/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING, Tuple, Type
+from typing import TYPE_CHECKING, Dict, Tuple, Type
 
 if TYPE_CHECKING:  # This prevents circular referencing between this file and potential_errors.py
     from mesido.potential_errors import ErrorMessage, MesidoAssetIssueType

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -2,17 +2,13 @@ import logging
 from abc import abstractmethod
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.timeseries import Timeseries
 
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.esdl.asset_to_component_base import AssetStateEnum
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.timeseries import Timeseries
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/gas_physics_mixin.py
+++ b/src/mesido/gas_physics_mixin.py
@@ -2,17 +2,14 @@ import copy
 import logging
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.timeseries import Timeseries
 
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.head_loss_class import HeadLossClass, HeadLossOption
 from mesido.network_common import NetworkSettings
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.timeseries import Timeseries
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/head_loss_class.py
+++ b/src/mesido/head_loss_class.py
@@ -4,17 +4,14 @@ from enum import IntEnum
 from typing import List, Optional, Tuple, Type, Union
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.optimization_problem import BT
 
 import mesido._darcy_weisbach as darcy_weisbach
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.network_common import NetworkSettings
 from mesido.pipe_class import PipeClass
-
-import numpy as np
-
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.optimization_problem import BT
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -3,19 +3,16 @@ import math
 from typing import List
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.timeseries import Timeseries
 
 from mesido._heat_loss_u_values_pipe import pipe_heat_loss
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.demand_insulation_class import DemandInsulationClass
 from mesido.head_loss_class import HeadLossClass, HeadLossOption
 from mesido.network_common import NetworkSettings
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.timeseries import Timeseries
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/influxdb/profile.py
+++ b/src/mesido/influxdb/profile.py
@@ -3,11 +3,9 @@ import sys
 from datetime import timedelta as td
 
 import esdl
+import pandas as pd
 from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
 from esdl.units.conversion import ENERGY_IN_J, POWER_IN_W, convert_to_unit
-
-
-import pandas as pd
 
 logger = logging.getLogger()
 

--- a/src/mesido/physics_mixin.py
+++ b/src/mesido/physics_mixin.py
@@ -1,19 +1,15 @@
 import logging
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
 
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.control_variables import map_comp_type_to_control_variable
 from mesido.electricity_physics_mixin import ElectricityPhysicsMixin
 from mesido.gas_physics_mixin import GasPhysicsMixin
 from mesido.heat_physics_mixin import HeatPhysicsMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/post_processing/post_processing_utils.py
+++ b/src/mesido/post_processing/post_processing_utils.py
@@ -2,12 +2,11 @@ import json
 import os
 from typing import Dict, Union
 
+import numpy as np
+from rtctools._internal.alias_tools import AliasDict
+
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.network_common import NetworkSettings
-
-import numpy as np
-
-from rtctools._internal.alias_tools import AliasDict
 
 
 class AliasDictResults:

--- a/src/mesido/pycml/__init__.py
+++ b/src/mesido/pycml/__init__.py
@@ -1,13 +1,5 @@
-from .model_base import (
-    Component,
-    Connector,
-    ConstantInput,
-    ControlInput,
-    FlattenedModel,
-    Model,
-    SymbolicParameter,
-    Variable,
-)
+from .model_base import (Component, Connector, ConstantInput, ControlInput,
+                         FlattenedModel, Model, SymbolicParameter, Variable)
 
 __all__ = [
     "Component",

--- a/src/mesido/pycml/component_library/milp/_internal/base_component.py
+++ b/src/mesido/pycml/component_library/milp/_internal/base_component.py
@@ -1,6 +1,6 @@
-from mesido.pycml import Component
-
 from numpy import nan
+
+from mesido.pycml import Component
 
 
 class BaseAsset(Component):

--- a/src/mesido/pycml/component_library/milp/_internal/electricity_component.py
+++ b/src/mesido/pycml/component_library/milp/_internal/electricity_component.py
@@ -1,5 +1,6 @@
 from mesido.network_common import NetworkSettings
-from mesido.pycml.component_library.milp._internal.base_component import BaseAsset
+from mesido.pycml.component_library.milp._internal.base_component import \
+    BaseAsset
 
 
 class ElectricityComponent(BaseAsset):

--- a/src/mesido/pycml/component_library/milp/_internal/gas_component.py
+++ b/src/mesido/pycml/component_library/milp/_internal/gas_component.py
@@ -1,5 +1,6 @@
 from mesido.network_common import NetworkSettings
-from mesido.pycml.component_library.milp._internal.base_component import BaseAsset
+from mesido.pycml.component_library.milp._internal.base_component import \
+    BaseAsset
 
 
 class GasComponent(BaseAsset):

--- a/src/mesido/pycml/component_library/milp/_internal/heat_component.py
+++ b/src/mesido/pycml/component_library/milp/_internal/heat_component.py
@@ -1,5 +1,6 @@
 from mesido.network_common import NetworkSettings
-from mesido.pycml.component_library.milp._internal.base_component import BaseAsset
+from mesido.pycml.component_library.milp._internal.base_component import \
+    BaseAsset
 
 
 class HeatComponent(BaseAsset):

--- a/src/mesido/pycml/component_library/milp/electricity/electricity_cable.py
+++ b/src/mesido/pycml/component_library/milp/electricity/electricity_cable.py
@@ -1,10 +1,10 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .electricity_base import ElectricityTwoPort
 from .._internal import BaseAsset
+from .electricity_base import ElectricityTwoPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/electricity/electricity_demand.py
+++ b/src/mesido/pycml/component_library/milp/electricity/electricity_demand.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .electricity_base import ElectricityPort
 from .._internal import BaseAsset
 from .._internal.electricity_component import ElectricityComponent
+from .electricity_base import ElectricityPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/electricity/electricity_node.py
+++ b/src/mesido/pycml/component_library/milp/electricity/electricity_node.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .electricity_base import ElectricityPort
 from .._internal import BaseAsset
 from .._internal.electricity_component import ElectricityComponent
+from .electricity_base import ElectricityPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/electricity/electricity_source.py
+++ b/src/mesido/pycml/component_library/milp/electricity/electricity_source.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .electricity_base import ElectricityPort
 from .._internal import BaseAsset
 from .._internal.electricity_component import ElectricityComponent
+from .electricity_base import ElectricityPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/electricity/electricity_storage.py
+++ b/src/mesido/pycml/component_library/milp/electricity/electricity_storage.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .electricity_base import ElectricityPort
 from .._internal import BaseAsset
 from .._internal.electricity_component import ElectricityComponent
+from .electricity_base import ElectricityPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/electricity/heat_pump_elec.py
+++ b/src/mesido/pycml/component_library/milp/electricity/heat_pump_elec.py
@@ -1,6 +1,5 @@
-from mesido.pycml.component_library.milp.electricity.electricity_base import (
-    ElectricityPort,
-)
+from mesido.pycml.component_library.milp.electricity.electricity_base import \
+    ElectricityPort
 from mesido.pycml.component_library.milp.heat.heat_pump import HeatPump
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 

--- a/src/mesido/pycml/component_library/milp/electricity/transformer.py
+++ b/src/mesido/pycml/component_library/milp/electricity/transformer.py
@@ -1,9 +1,9 @@
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
 
-from .electricity_base import ElectricityTwoPort
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
+
 from .._internal import BaseAsset
+from .electricity_base import ElectricityTwoPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/compressor.py
+++ b/src/mesido/pycml/component_library/milp/gas/compressor.py
@@ -1,9 +1,9 @@
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
 
-from .gas_base import GasTwoPort
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
+
 from .._internal import BaseAsset
+from .gas_base import GasTwoPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/gas_demand.py
+++ b/src/mesido/pycml/component_library/milp/gas/gas_demand.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .gas_base import GasPort
 from .._internal import BaseAsset
 from .._internal.gas_component import GasComponent
+from .gas_base import GasPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/gas_node.py
+++ b/src/mesido/pycml/component_library/milp/gas/gas_node.py
@@ -1,9 +1,9 @@
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from .gas_base import GasPort
 from .._internal import BaseAsset
 from .._internal.gas_component import GasComponent
+from .gas_base import GasPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/gas_pipe.py
+++ b/src/mesido/pycml/component_library/milp/gas/gas_pipe.py
@@ -1,10 +1,10 @@
+from numpy import nan, pi
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan, pi
-
-from .gas_base import GasTwoPort
 from .._internal import BaseAsset
+from .gas_base import GasTwoPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/gas_source.py
+++ b/src/mesido/pycml/component_library/milp/gas/gas_source.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .gas_base import GasPort
 from .._internal import BaseAsset
 from .._internal.gas_component import GasComponent
+from .gas_base import GasPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/gas_substation.py
+++ b/src/mesido/pycml/component_library/milp/gas/gas_substation.py
@@ -1,9 +1,9 @@
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
 
-from .gas_base import GasTwoPort
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
+
 from .._internal import BaseAsset
+from .gas_base import GasTwoPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/gas/gas_tank_storage.py
+++ b/src/mesido/pycml/component_library/milp/gas/gas_tank_storage.py
@@ -1,11 +1,11 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.component_library.milp._internal import BaseAsset
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
-from numpy import nan
-
-from .gas_base import GasPort
 from .._internal.gas_component import GasComponent
+from .gas_base import GasPort
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/heat/_non_storage_component.py
+++ b/src/mesido/pycml/component_library/milp/heat/_non_storage_component.py
@@ -1,8 +1,9 @@
-from mesido.pycml import Variable
-from mesido.pycml.component_library.milp._internal.heat_component import BaseAsset
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
+
+from mesido.pycml import Variable
+from mesido.pycml.component_library.milp._internal.heat_component import \
+    BaseAsset
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 from .heat_two_port import HeatTwoPort
 

--- a/src/mesido/pycml/component_library/milp/heat/ates.py
+++ b/src/mesido/pycml/component_library/milp/heat/ates.py
@@ -1,8 +1,9 @@
-from mesido.pycml import Variable
-from mesido.pycml.component_library.milp._internal.heat_component import BaseAsset
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
+
+from mesido.pycml import Variable
+from mesido.pycml.component_library.milp._internal.heat_component import \
+    BaseAsset
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 from .heat_two_port import HeatTwoPort
 

--- a/src/mesido/pycml/component_library/milp/heat/geothermal_source.py
+++ b/src/mesido/pycml/component_library/milp/heat/geothermal_source.py
@@ -1,6 +1,6 @@
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
+
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 from .heat_source import HeatSource
 

--- a/src/mesido/pycml/component_library/milp/heat/heat_buffer.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_buffer.py
@@ -1,10 +1,11 @@
 import math
 
-from mesido.pycml import Variable
-from mesido.pycml.component_library.milp._internal.heat_component import BaseAsset
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
+
+from mesido.pycml import Variable
+from mesido.pycml.component_library.milp._internal.heat_component import \
+    BaseAsset
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 from .heat_two_port import HeatTwoPort
 

--- a/src/mesido/pycml/component_library/milp/heat/heat_exchanger.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_exchanger.py
@@ -1,9 +1,10 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.component_library.milp._internal import BaseAsset
-from mesido.pycml.component_library.milp.heat.heat_four_port import HeatFourPort
+from mesido.pycml.component_library.milp.heat.heat_four_port import \
+    HeatFourPort
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/heat/heat_pipe.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_pipe.py
@@ -1,7 +1,7 @@
+from numpy import nan, pi
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan, pi
 
 from ._non_storage_component import _NonStorageComponent
 

--- a/src/mesido/pycml/component_library/milp/heat/heat_pump.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_pump.py
@@ -1,9 +1,10 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.component_library.milp._internal import BaseAsset
-from mesido.pycml.component_library.milp.heat.heat_four_port import HeatFourPort
+from mesido.pycml.component_library.milp.heat.heat_four_port import \
+    HeatFourPort
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/heat/heat_source.py
+++ b/src/mesido/pycml/component_library/milp/heat/heat_source.py
@@ -1,7 +1,7 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 from ._non_storage_component import _NonStorageComponent
 

--- a/src/mesido/pycml/component_library/milp/heat/low_temperature_ates.py
+++ b/src/mesido/pycml/component_library/milp/heat/low_temperature_ates.py
@@ -1,8 +1,9 @@
-from mesido.pycml import Variable
-from mesido.pycml.component_library.milp._internal.heat_component import BaseAsset
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
+
+from mesido.pycml import Variable
+from mesido.pycml.component_library.milp._internal.heat_component import \
+    BaseAsset
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 from .heat_two_port import HeatTwoPort
 

--- a/src/mesido/pycml/component_library/milp/heat/node.py
+++ b/src/mesido/pycml/component_library/milp/heat/node.py
@@ -1,5 +1,6 @@
 from mesido.pycml import Variable
-from mesido.pycml.component_library.milp._internal import BaseAsset, HeatComponent
+from mesido.pycml.component_library.milp._internal import (BaseAsset,
+                                                           HeatComponent)
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 from .heat_port import HeatPort

--- a/src/mesido/pycml/component_library/milp/heat/pump.py
+++ b/src/mesido/pycml/component_library/milp/heat/pump.py
@@ -1,7 +1,7 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 from ._non_storage_component import _NonStorageComponent
 

--- a/src/mesido/pycml/component_library/milp/multicommodity/airwater_heat_pump_elec.py
+++ b/src/mesido/pycml/component_library/milp/multicommodity/airwater_heat_pump_elec.py
@@ -1,9 +1,11 @@
-from mesido.pycml import Variable
-from mesido.pycml.component_library.milp.electricity.electricity_base import ElectricityPort
-from mesido.pycml.component_library.milp.heat.air_water_heat_pump import AirWaterHeatPump
-from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
 from numpy import nan
+
+from mesido.pycml import Variable
+from mesido.pycml.component_library.milp.electricity.electricity_base import \
+    ElectricityPort
+from mesido.pycml.component_library.milp.heat.air_water_heat_pump import \
+    AirWaterHeatPump
+from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/multicommodity/electro_boiler.py
+++ b/src/mesido/pycml/component_library/milp/multicommodity/electro_boiler.py
@@ -1,9 +1,10 @@
+from numpy import nan
+
 from mesido.pycml import Variable
-from mesido.pycml.component_library.milp.electricity.electricity_base import ElectricityPort
+from mesido.pycml.component_library.milp.electricity.electricity_base import \
+    ElectricityPort
 from mesido.pycml.component_library.milp.heat.heat_source import HeatSource
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/multicommodity/electrolyzer.py
+++ b/src/mesido/pycml/component_library/milp/multicommodity/electrolyzer.py
@@ -1,17 +1,13 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.component_library.milp._internal import BaseAsset
-from mesido.pycml.component_library.milp._internal.electricity_component import (
-    ElectricityComponent,
-)
-from mesido.pycml.component_library.milp.electricity.electricity_base import (
-    ElectricityPort,
-)
-from mesido.pycml.component_library.milp.gas.gas_base import (
-    GasPort,
-)
+from mesido.pycml.component_library.milp._internal.electricity_component import \
+    ElectricityComponent
+from mesido.pycml.component_library.milp.electricity.electricity_base import \
+    ElectricityPort
+from mesido.pycml.component_library.milp.gas.gas_base import GasPort
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/milp/multicommodity/gas_boiler.py
+++ b/src/mesido/pycml/component_library/milp/multicommodity/gas_boiler.py
@@ -1,9 +1,9 @@
+from numpy import nan
+
 from mesido.pycml import Variable
 from mesido.pycml.component_library.milp.gas.gas_base import GasPort
 from mesido.pycml.component_library.milp.heat.heat_source import HeatSource
 from mesido.pycml.pycml_mixin import add_variables_documentation_automatically
-
-from numpy import nan
 
 
 @add_variables_documentation_automatically

--- a/src/mesido/pycml/component_library/qth/buffer.py
+++ b/src/mesido/pycml/component_library/qth/buffer.py
@@ -1,8 +1,8 @@
 import math
 
-from mesido.pycml import Variable
-
 from numpy import nan
+
+from mesido.pycml import Variable
 
 from ._fluid_properties_component import _FluidPropertiesComponent
 

--- a/src/mesido/pycml/component_library/qth/pipe.py
+++ b/src/mesido/pycml/component_library/qth/pipe.py
@@ -1,6 +1,6 @@
-from mesido.pycml import Variable
-
 from numpy import nan, pi
+
+from mesido.pycml import Variable
 
 from ._fluid_properties_component import _FluidPropertiesComponent
 from ._non_storage_component import _NonStorageComponent

--- a/src/mesido/pycml/component_library/qth/source.py
+++ b/src/mesido/pycml/component_library/qth/source.py
@@ -1,6 +1,6 @@
-from mesido.pycml import SymbolicParameter, Variable
-
 from numpy import nan
+
+from mesido.pycml import SymbolicParameter, Variable
 
 from ._fluid_properties_component import _FluidPropertiesComponent
 from ._non_storage_component import _NonStorageComponent

--- a/src/mesido/pycml/model_base.py
+++ b/src/mesido/pycml/model_base.py
@@ -1,11 +1,8 @@
 from typing import Dict, List, Tuple, Union
 
 import casadi as ca
-
 import numpy as np
-
 from pymoca.backends.casadi.model import Variable as _Variable
-
 
 MATHEMATICAL_OPERATORS = [
     "__add__",

--- a/src/mesido/pycml/pycml_mixin.py
+++ b/src/mesido/pycml/pycml_mixin.py
@@ -6,16 +6,13 @@ from abc import abstractmethod
 from typing import Dict, List, Type, Union
 
 import casadi as ca
-
 import pymoca
 from pymoca.backends.casadi.model import Model as _Model
-
 from rtctools._internal.alias_tools import AliasDict
 from rtctools._internal.caching import cached
 from rtctools.optimization.optimization_problem import OptimizationProblem
 
 from . import ConstantInput, ControlInput, Model, SymbolicParameter, Variable
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/qth_not_maintained/bounds_to_pipe_flow_directions_mixin.py
+++ b/src/mesido/qth_not_maintained/bounds_to_pipe_flow_directions_mixin.py
@@ -1,11 +1,10 @@
 from typing import Dict
 
+import numpy as np
+from rtctools.optimization.timeseries import Timeseries
+
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.heat_network_common import PipeFlowDirection
-
-import numpy as np
-
-from rtctools.optimization.timeseries import Timeseries
 
 
 class BoundsToPipeFlowDirectionsMixin(BaseComponentTypeMixin):

--- a/src/mesido/qth_not_maintained/head_loss_mixin.py
+++ b/src/mesido/qth_not_maintained/head_loss_mixin.py
@@ -4,19 +4,17 @@ from enum import IntEnum
 from typing import List, Optional, Tuple, Type, Union
 
 import casadi as ca
+import numpy as np
+from rtctools._internal.alias_tools import AliasDict
+from rtctools.optimization.goal_programming_mixin_base import (
+    Goal, _GoalProgrammingMixinBase)
+from rtctools.optimization.optimization_problem import BT, OptimizationProblem
 
 import mesido._darcy_weisbach as darcy_weisbach
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 
-import numpy as np
-
-from rtctools._internal.alias_tools import AliasDict
-from rtctools.optimization.goal_programming_mixin_base import Goal, _GoalProgrammingMixinBase
-from rtctools.optimization.optimization_problem import BT, OptimizationProblem
-
 from ..constants import GRAVITATIONAL_CONSTANT
 from ..pipe_class import PipeClass
-
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/qth_not_maintained/qth_loop_mixin.py
+++ b/src/mesido/qth_not_maintained/qth_loop_mixin.py
@@ -1,14 +1,12 @@
 from typing import Dict, List, Tuple
 
 import casadi as ca
-
-from mesido.qth_not_maintained.qth_mixin import HeadLossOption, QTHMixin
-
 import numpy as np
-
 from rtctools._internal.alias_tools import AliasDict
 from rtctools.optimization.goal_programming_mixin_base import Goal
 from rtctools.optimization.timeseries import Timeseries
+
+from mesido.qth_not_maintained.qth_mixin import HeadLossOption, QTHMixin
 
 
 class BufferTargetDischargeGoal(Goal):

--- a/src/mesido/qth_not_maintained/qth_mixin.py
+++ b/src/mesido/qth_not_maintained/qth_mixin.py
@@ -4,29 +4,24 @@ from math import isfinite
 from typing import Dict
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.homotopy_mixin import HomotopyMixin
+from rtctools.optimization.timeseries import Timeseries
 
 from mesido._heat_loss_u_values_pipe import heat_loss_u_values_pipe
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
-from mesido.heat_network_common import (
-    CheckValveStatus,
-    ControlValveDirection,
-    NodeConnectionDirection,
-    PipeFlowDirection,
-)
-from mesido.qth_not_maintained.head_loss_mixin import (
-    HeadLossOption,
-    _HeadLossMixin,
-    _MinimizeHeadLosses as _MinimizeHeadLossesBase,
-    _MinimizeHydraulicPower as _MinimizeHydraulicPowerBase,
-)
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.homotopy_mixin import HomotopyMixin
-from rtctools.optimization.timeseries import Timeseries
+from mesido.heat_network_common import (CheckValveStatus,
+                                        ControlValveDirection,
+                                        NodeConnectionDirection,
+                                        PipeFlowDirection)
+from mesido.qth_not_maintained.head_loss_mixin import (HeadLossOption,
+                                                       _HeadLossMixin)
+from mesido.qth_not_maintained.head_loss_mixin import \
+    _MinimizeHeadLosses as _MinimizeHeadLossesBase
+from mesido.qth_not_maintained.head_loss_mixin import \
+    _MinimizeHydraulicPower as _MinimizeHydraulicPowerBase
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/techno_economic_mixin.py
+++ b/src/mesido/techno_economic_mixin.py
@@ -1,13 +1,12 @@
 import logging
 
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+
 from mesido.asset_sizing_mixin import AssetSizingMixin
 from mesido.base_component_type_mixin import BaseComponentTypeMixin
 from mesido.financial_mixin import FinancialMixin
 from mesido.physics_mixin import PhysicsMixin
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/util.py
+++ b/src/mesido/util.py
@@ -1,10 +1,9 @@
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_parser import BaseESDLParser
 from mesido.esdl.profile_parser import BaseProfileReader, InfluxDBProfileReader
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.util import run_optimization_problem
 
 
 def run_esdl_mesido_optimization(

--- a/src/mesido/workflows/__init__.py
+++ b/src/mesido/workflows/__init__.py
@@ -1,24 +1,14 @@
-from .grow_workflow import (
-    EndScenarioSizing,
-    EndScenarioSizingDiscounted,
-    EndScenarioSizingDiscountedStaged,
-    EndScenarioSizingHIGHS,
-    EndScenarioSizingHeadLossDiscounted,
-    EndScenarioSizingHeadLossDiscountedStaged,
-    EndScenarioSizingHeadLossStaged,
-    EndScenarioSizingStaged,
-    SolverGurobi,
-    SolverHIGHS,
-    run_end_scenario_sizing,
-    run_end_scenario_sizing_no_heat_losses,
-)
-from .simulator_workflow import (
-    NetworkSimulator,
-    NetworkSimulatorHIGHS,
-    NetworkSimulatorHIGHSTestCase,
-    NetworkSimulatorHIGHSWeeklyTimeStep,
-)
-
+from .grow_workflow import (EndScenarioSizing, EndScenarioSizingDiscounted,
+                            EndScenarioSizingDiscountedStaged,
+                            EndScenarioSizingHeadLossDiscounted,
+                            EndScenarioSizingHeadLossDiscountedStaged,
+                            EndScenarioSizingHeadLossStaged,
+                            EndScenarioSizingHIGHS, EndScenarioSizingStaged,
+                            SolverGurobi, SolverHIGHS, run_end_scenario_sizing,
+                            run_end_scenario_sizing_no_heat_losses)
+from .simulator_workflow import (NetworkSimulator, NetworkSimulatorHIGHS,
+                                 NetworkSimulatorHIGHSTestCase,
+                                 NetworkSimulatorHIGHSWeeklyTimeStep)
 
 __all__ = [
     "EndScenarioSizing",

--- a/src/mesido/workflows/emerge.py
+++ b/src/mesido/workflows/emerge.py
@@ -2,6 +2,14 @@ import os
 import time
 
 import casadi as ca
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
@@ -10,16 +18,6 @@ from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.io.write_output import ScenarioOutput
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.util import run_optimization_problem
 
 
 class MaxRevenue(Goal):

--- a/src/mesido/workflows/gas_elect_workflow.py
+++ b/src/mesido/workflows/gas_elect_workflow.py
@@ -1,6 +1,16 @@
 import logging
 import os
 
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import (
+    CachingQPSol, SinglePassGoalProgrammingMixin)
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.head_loss_class import HeadLossOption
@@ -9,21 +19,6 @@ from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.goals.minimize_tco_goal import MinimizeTCO
 from mesido.workflows.io.write_output import ScenarioOutput
 from mesido.workflows.utils.helpers import main_decorator
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import (
-    CachingQPSol,
-    SinglePassGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 logger = logging.getLogger("WarmingUP-MPC")
 logger.setLevel(logging.INFO)

--- a/src/mesido/workflows/goals/minimize_tco_goal.py
+++ b/src/mesido/workflows/goals/minimize_tco_goal.py
@@ -1,11 +1,10 @@
 from typing import Any, Dict, Optional, Set
 
 from casadi import MX
+from rtctools.optimization.goal_programming_mixin_base import Goal
 
 from mesido.esdl.asset_to_component_base import AssetStateEnum
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-from rtctools.optimization.goal_programming_mixin_base import Goal
 
 
 class MinimizeTCO(Goal):

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -5,6 +5,16 @@ import sys
 import time
 from typing import Dict
 
+import numpy as np
+from rtctools._internal.alias_tools import AliasDict
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import (
+    CachingQPSol, SinglePassGoalProgrammingMixin)
+
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.head_loss_class import HeadLossOption
@@ -12,27 +22,12 @@ from mesido.potential_errors import reset_potential_errors
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.goals.minimize_tco_goal import MinimizeTCO
 from mesido.workflows.io.write_output import ScenarioOutput
-from mesido.workflows.utils.adapt_profiles import (
-    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day,
-)
-from mesido.workflows.utils.error_types import HEAT_NETWORK_ERRORS, potential_error_to_error
-from mesido.workflows.utils.helpers import main_decorator, run_optimization_problem_solver
-
-import numpy as np
-
-from rtctools._internal.alias_tools import AliasDict
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import (
-    CachingQPSol,
-    SinglePassGoalProgrammingMixin,
-)
-
+from mesido.workflows.utils.adapt_profiles import \
+    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day
+from mesido.workflows.utils.error_types import (HEAT_NETWORK_ERRORS,
+                                                potential_error_to_error)
+from mesido.workflows.utils.helpers import (main_decorator,
+                                            run_optimization_problem_solver)
 
 DB_HOST = "172.17.0.2"
 DB_PORT = 8086

--- a/src/mesido/workflows/io/read_files_and_create_influxdb.py
+++ b/src/mesido/workflows/io/read_files_and_create_influxdb.py
@@ -2,8 +2,8 @@ import glob
 import os
 
 from esdl.profiles.excelprofilemanager import ExcelProfileManager
-from esdl.profiles.influxdbprofilemanager import ConnectionSettings
-from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
+from esdl.profiles.influxdbprofilemanager import (ConnectionSettings,
+                                                  InfluxDBProfileManager)
 
 """
 Place raw excel files in fodler: raw_data_files_folder

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -12,23 +12,21 @@ from pathlib import Path
 from typing import Dict, Union
 
 import esdl
-from esdl.profiles.influxdbprofilemanager import ConnectionSettings
-from esdl.profiles.influxdbprofilemanager import InfluxDBProfileManager
+import numpy as np
+import pandas as pd
+from esdl.profiles.influxdbprofilemanager import (ConnectionSettings,
+                                                  InfluxDBProfileManager)
 from esdl.profiles.profilemanager import ProfileManager
+from rtctools._internal.alias_tools import AliasDict
+from rtctools.optimization.timeseries import Timeseries
 
 import mesido.esdl.esdl_parser
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.esdl.edr_pipe_class import EDRPipeClass
 from mesido.network_common import NetworkSettings
-from mesido.post_processing.post_processing_utils import pipe_pressure, pipe_velocity
+from mesido.post_processing.post_processing_utils import (pipe_pressure,
+                                                          pipe_velocity)
 from mesido.workflows.utils.helpers import _sort_numbered
-
-import numpy as np
-
-import pandas as pd
-
-from rtctools._internal.alias_tools import AliasDict
-from rtctools.optimization.timeseries import Timeseries
 
 logger = logging.getLogger("mesido")
 

--- a/src/mesido/workflows/multicommodity_simulator_workflow.py
+++ b/src/mesido/workflows/multicommodity_simulator_workflow.py
@@ -4,6 +4,16 @@ import time
 from pathlib import Path
 
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import (
+    CachingQPSol, SinglePassGoalProgrammingMixin)
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
@@ -13,22 +23,6 @@ from mesido.network_common import NetworkSettings
 from mesido.physics_mixin import PhysicsMixin
 from mesido.workflows.io.write_output import ScenarioOutput
 from mesido.workflows.utils.helpers import main_decorator
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import (
-    CachingQPSol,
-    SinglePassGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 DB_HOST = "172.17.0.2"
 DB_PORT = 8086

--- a/src/mesido/workflows/simulator_workflow.py
+++ b/src/mesido/workflows/simulator_workflow.py
@@ -2,31 +2,23 @@ import locale
 import logging
 
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import (
+    CachingQPSol, SinglePassGoalProgrammingMixin)
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.io.write_output import ScenarioOutput
-from mesido.workflows.utils.adapt_profiles import (
-    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day,
-)
+from mesido.workflows.utils.adapt_profiles import \
+    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day
 from mesido.workflows.utils.helpers import main_decorator
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import (
-    CachingQPSol,
-    SinglePassGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
-
 
 DB_HOST = "172.17.0.2"
 DB_PORT = 8086

--- a/src/mesido/workflows/utils/adapt_profiles.py
+++ b/src/mesido/workflows/utils/adapt_profiles.py
@@ -6,9 +6,7 @@ import operator
 import sys
 
 import numpy as np
-
 from rtctools.data.storage import DataStore
-
 
 logger = logging.getLogger("WarmingUP-MPC")
 logger.setLevel(logging.INFO)

--- a/src/mesido/workflows/utils/helpers.py
+++ b/src/mesido/workflows/utils/helpers.py
@@ -6,11 +6,9 @@ import time
 from pathlib import Path
 
 import esdl
-
-from mesido import __version__
-
 from rtctools.util import run_optimization_problem
 
+from mesido import __version__
 
 MULTI_ENUM_NAME_TO_FACTOR = {
     esdl.MultiplierEnum.ATTO: 1e-18,
@@ -105,6 +103,7 @@ def main_decorator(func):
 
         if run_remote:
             import inspect
+
             from warmingup_mpc.amqp_client import AMQPClient
 
             workflow_name = Path(inspect.getfile(func)).stem

--- a/tests/models/absolute_heat/src/example.py
+++ b/tests/models/absolute_heat/src/example.py
@@ -1,22 +1,19 @@
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/ates_temperature/src/run_ates_temperature.py
+++ b/tests/models/ates_temperature/src/run_ates_temperature.py
@@ -1,24 +1,20 @@
+import numpy as np
+from rtctools.data.storage import DataStore
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    GoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.io.write_output import ScenarioOutput
-
-import numpy as np
-
-from rtctools.data.storage import DataStore
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import (
-    GoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 ns = {"fews": "http://www.wldelft.nl/fews", "pi": "http://www.wldelft.nl/fews/PI"}
 

--- a/tests/models/basic_buffer/src/compare.py
+++ b/tests/models/basic_buffer/src/compare.py
@@ -3,15 +3,13 @@ import time
 from abc import ABCMeta
 from pathlib import Path
 
+from rtctools.optimization.modelica_mixin import ModelicaMixin
+
 from mesido.pycml.pycml_mixin import PyCMLMixin
 from mesido.qth_not_maintained.qth_loop_mixin import (
-    BufferTargetDischargeGoal,
-    QTHLoopMixin,
-)
+    BufferTargetDischargeGoal, QTHLoopMixin)
 from mesido.qth_not_maintained.qth_mixin import QTHMixin
 from mesido.qth_not_maintained.util import run_heat_network_optimization
-
-from rtctools.optimization.modelica_mixin import ModelicaMixin
 
 # We want to import the example we compare with as a module that is somewhat
 # uniquely identifiable. We therefore start from the root.
@@ -19,10 +17,9 @@ root_folder = str(Path(__file__).resolve().parent.parent.parent.parent.parent)
 sys.path.insert(1, root_folder)
 
 import examples.basic_buffer.src.example  # noqa: E402, I100
-from examples.basic_buffer.src.example import (  # noqa: E402, I100
-    HeatProblem as _HeatProblem,
-    QTHProblem as _QTHProblem,
-)
+from examples.basic_buffer.src.example import \
+    HeatProblem as _HeatProblem  # noqa: E402, I100
+from examples.basic_buffer.src.example import QTHProblem as _QTHProblem
 
 base_folder = Path(examples.basic_buffer.src.example.__file__).resolve().parent.parent
 

--- a/tests/models/basic_buffer/src/model_heat.py
+++ b/tests/models/basic_buffer/src/model_heat.py
@@ -1,12 +1,9 @@
-from mesido.pycml import ControlInput, Model as _Model, Variable
-from mesido.pycml.component_library.milp import (
-    HeatBuffer,
-    HeatDemand,
-    HeatPipe,
-    HeatSource,
-    Node,
-    Pump,
-)
+from mesido.pycml import ControlInput
+from mesido.pycml import Model as _Model
+from mesido.pycml import Variable
+from mesido.pycml.component_library.milp import (HeatBuffer, HeatDemand,
+                                                 HeatPipe, HeatSource, Node,
+                                                 Pump)
 
 
 class ModelHeat(_Model):

--- a/tests/models/basic_buffer/src/model_qth.py
+++ b/tests/models/basic_buffer/src/model_qth.py
@@ -1,12 +1,8 @@
-from mesido.pycml import ControlInput, Model as _Model, SymbolicParameter, Variable
-from mesido.pycml.component_library.qth import (
-    Buffer,
-    Demand,
-    Node,
-    Pipe,
-    Pump,
-    Source,
-)
+from mesido.pycml import ControlInput
+from mesido.pycml import Model as _Model
+from mesido.pycml import SymbolicParameter, Variable
+from mesido.pycml.component_library.qth import (Buffer, Demand, Node, Pipe,
+                                                Pump, Source)
 
 
 class ModelQTH(_Model):

--- a/tests/models/basic_source_and_demand/src/heat_comparison.py
+++ b/tests/models/basic_source_and_demand/src/heat_comparison.py
@@ -1,15 +1,15 @@
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.csv_mixin import CSVMixin
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.modelica_mixin import ModelicaMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.component_type_mixin import ModelicaComponentTypeMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.physics_mixin import PhysicsMixin
 from mesido.pycml.pycml_mixin import PyCMLMixin
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.csv_mixin import CSVMixin
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.modelica_mixin import ModelicaMixin
-from rtctools.util import run_optimization_problem
 
 if __name__ == "__main__":
     from model_heat import Model

--- a/tests/models/basic_source_and_demand/src/model_heat.py
+++ b/tests/models/basic_source_and_demand/src/model_heat.py
@@ -1,10 +1,7 @@
-from mesido.pycml import ControlInput, Model as _Model
-from mesido.pycml.component_library.milp import (
-    HeatDemand,
-    HeatPipe,
-    HeatSource,
-    Pump,
-)
+from mesido.pycml import ControlInput
+from mesido.pycml import Model as _Model
+from mesido.pycml.component_library.milp import (HeatDemand, HeatPipe,
+                                                 HeatSource, Pump)
 
 
 class Model(_Model):

--- a/tests/models/basic_source_and_demand/src/model_qth.py
+++ b/tests/models/basic_source_and_demand/src/model_qth.py
@@ -1,4 +1,6 @@
-from mesido.pycml import ControlInput, Model as _Model, SymbolicParameter
+from mesido.pycml import ControlInput
+from mesido.pycml import Model as _Model
+from mesido.pycml import SymbolicParameter
 from mesido.pycml.component_library.qth import Demand, Pipe, Pump, Source
 
 

--- a/tests/models/basic_source_and_demand/src/qth_comparison.py
+++ b/tests/models/basic_source_and_demand/src/qth_comparison.py
@@ -1,22 +1,20 @@
-from mesido.component_type_mixin import ModelicaComponentTypeMixin
-from mesido.esdl.esdl_mixin import ESDLMixin
-from mesido.pycml.pycml_mixin import PyCMLMixin
-from mesido.qth_not_maintained.bounds_to_pipe_flow_directions_mixin import (
-    BoundsToPipeFlowDirectionsMixin,
-)
-from mesido.qth_not_maintained.qth_mixin import QTHMixin
-
 import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
 from rtctools.optimization.csv_mixin import CSVMixin
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
 from rtctools.optimization.homotopy_mixin import HomotopyMixin
 from rtctools.optimization.modelica_mixin import ModelicaMixin
 from rtctools.optimization.timeseries import Timeseries
 from rtctools.util import run_optimization_problem
+
+from mesido.component_type_mixin import ModelicaComponentTypeMixin
+from mesido.esdl.esdl_mixin import ESDLMixin
+from mesido.pycml.pycml_mixin import PyCMLMixin
+from mesido.qth_not_maintained.bounds_to_pipe_flow_directions_mixin import \
+    BoundsToPipeFlowDirectionsMixin
+from mesido.qth_not_maintained.qth_mixin import QTHMixin
 
 if __name__ == "__main__":
     from model_qth import Model

--- a/tests/models/basic_source_and_demand/src/qth_minimize_temperatures.py
+++ b/tests/models/basic_source_and_demand/src/qth_minimize_temperatures.py
@@ -1,18 +1,18 @@
-from mesido.component_type_mixin import ModelicaComponentTypeMixin
-from mesido.pycml.pycml_mixin import PyCMLMixin
-from mesido.qth_not_maintained.bounds_to_pipe_flow_directions_mixin import (
-    BoundsToPipeFlowDirectionsMixin,
-)
-from mesido.qth_not_maintained.qth_mixin import DemandTemperatureOption, QTHMixin
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
 from rtctools.optimization.csv_mixin import CSVMixin
 from rtctools.optimization.goal_programming_mixin import Goal
 from rtctools.optimization.homotopy_mixin import HomotopyMixin
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
 from rtctools.util import run_optimization_problem
+
+from mesido.component_type_mixin import ModelicaComponentTypeMixin
+from mesido.pycml.pycml_mixin import PyCMLMixin
+from mesido.qth_not_maintained.bounds_to_pipe_flow_directions_mixin import \
+    BoundsToPipeFlowDirectionsMixin
+from mesido.qth_not_maintained.qth_mixin import (DemandTemperatureOption,
+                                                 QTHMixin)
 
 if __name__ == "__main__":
     from model_qth import Model

--- a/tests/models/double_pipe_heat/src/double_pipe_heat.py
+++ b/tests/models/double_pipe_heat/src/double_pipe_heat.py
@@ -1,13 +1,13 @@
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.csv_mixin import CSVMixin
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.util import run_optimization_problem
+
 from mesido.component_type_mixin import ModelicaComponentTypeMixin
 from mesido.physics_mixin import PhysicsMixin
 from mesido.pycml.pycml_mixin import PyCMLMixin
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.csv_mixin import CSVMixin
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.util import run_optimization_problem
 
 if __name__ == "__main__":
     from model import Model

--- a/tests/models/double_pipe_heat/src/model.py
+++ b/tests/models/double_pipe_heat/src/model.py
@@ -1,11 +1,7 @@
-from mesido.pycml import ControlInput, Model as _Model
-from mesido.pycml.component_library.milp import (
-    HeatDemand,
-    HeatPipe,
-    HeatSource,
-    Node,
-    Pump,
-)
+from mesido.pycml import ControlInput
+from mesido.pycml import Model as _Model
+from mesido.pycml.component_library.milp import (HeatDemand, HeatPipe,
+                                                 HeatSource, Node, Pump)
 
 
 class Model(_Model):

--- a/tests/models/double_pipe_qth/src/cq2_inequality_vs_equality.py
+++ b/tests/models/double_pipe_qth/src/cq2_inequality_vs_equality.py
@@ -1,9 +1,9 @@
 from abc import ABCMeta
 
+from rtctools.util import run_optimization_problem
+
 from mesido.qth_not_maintained.qth_loop_mixin import QTHLoopMixin
 from mesido.qth_not_maintained.qth_mixin import HeadLossOption, QTHMixin
-
-from rtctools.util import run_optimization_problem
 
 if __name__ == "__main__":
     from double_pipe_qth import DoublePipeBase

--- a/tests/models/double_pipe_qth/src/double_pipe_qth.py
+++ b/tests/models/double_pipe_qth/src/double_pipe_qth.py
@@ -1,17 +1,16 @@
-from mesido.component_type_mixin import ModelicaComponentTypeMixin
-from mesido.qth_not_maintained.bounds_to_pipe_flow_directions_mixin import (
-    BoundsToPipeFlowDirectionsMixin,
-)
-from mesido.qth_not_maintained.qth_mixin import QTHMixin
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
 from rtctools.optimization.csv_mixin import CSVMixin
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
 from rtctools.optimization.homotopy_mixin import HomotopyMixin
 from rtctools.optimization.modelica_mixin import ModelicaMixin
 from rtctools.util import run_optimization_problem
+
+from mesido.component_type_mixin import ModelicaComponentTypeMixin
+from mesido.qth_not_maintained.bounds_to_pipe_flow_directions_mixin import \
+    BoundsToPipeFlowDirectionsMixin
+from mesido.qth_not_maintained.qth_mixin import QTHMixin
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/double_pipe_qth/src/single_pipe_no_headloss.py
+++ b/tests/models/double_pipe_qth/src/single_pipe_no_headloss.py
@@ -1,6 +1,6 @@
-from mesido.qth_not_maintained.qth_mixin import HeadLossOption
-
 from rtctools.util import run_optimization_problem
+
+from mesido.qth_not_maintained.qth_mixin import HeadLossOption
 
 if __name__ == "__main__":
     from double_pipe_qth import SinglePipeQTH

--- a/tests/models/electricity_cable_topology/src/example.py
+++ b/tests/models/electricity_cable_topology/src/example.py
@@ -1,23 +1,20 @@
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.pipe_class import CableClass
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/emerge/src/example.py
+++ b/tests/models/emerge/src/example.py
@@ -1,6 +1,13 @@
 import time
 
 import casadi as ca
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
 
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
@@ -10,18 +17,7 @@ from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.io.write_output import ScenarioOutput
 from mesido.workflows.multicommodity_simulator_workflow import (
-    MultiCommoditySimulatorNoLosses,
-    run_sequatially_staged_simulation,
-)
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
+    MultiCommoditySimulatorNoLosses, run_sequatially_staged_simulation)
 
 
 class MaxHydrogenProduction(Goal):

--- a/tests/models/gas_pipe_topology/src/example.py
+++ b/tests/models/gas_pipe_topology/src/example.py
@@ -1,22 +1,19 @@
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/heat_exchange/src/run_heat_exchanger.py
+++ b/tests/models/heat_exchange/src/run_heat_exchanger.py
@@ -1,20 +1,18 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.physics_mixin import PhysicsMixin
 from mesido.workflows.io.write_output import ScenarioOutput
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/heatpump/src/run_heat_pump.py
+++ b/tests/models/heatpump/src/run_heat_pump.py
@@ -1,19 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
 from mesido.workflows.io.write_output import ScenarioOutput
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/insulation/src/run_insulation.py
+++ b/tests/models/insulation/src/run_insulation.py
@@ -1,21 +1,18 @@
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
 
 from mesido.demand_insulation_class import DemandInsulationClass
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class MinimizeSourcesHeatGoal(Goal):

--- a/tests/models/multiple_carriers/src/run_multiple_carriers.py
+++ b/tests/models/multiple_carriers/src/run_multiple_carriers.py
@@ -1,18 +1,16 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/multiple_gas_carriers/src/run_multiple_gas_carriers.py
+++ b/tests/models/multiple_gas_carriers/src/run_multiple_gas_carriers.py
@@ -1,20 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/pipe_test/src/run_hydraulic_power.py
+++ b/tests/models/pipe_test/src/run_hydraulic_power.py
@@ -1,18 +1,15 @@
+import numpy as np
+import pandas as pd
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.head_loss_class import HeadLossOption
 from mesido.physics_mixin import PhysicsMixin
-
-import numpy as np
-
-import pandas as pd
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/simple_buffer/src/model.py
+++ b/tests/models/simple_buffer/src/model.py
@@ -1,12 +1,8 @@
-from mesido.pycml import ControlInput, Model as _Model
-from mesido.pycml.component_library.milp import (
-    HeatBuffer,
-    HeatDemand,
-    HeatPipe,
-    HeatSource,
-    Node,
-    Pump,
-)
+from mesido.pycml import ControlInput
+from mesido.pycml import Model as _Model
+from mesido.pycml.component_library.milp import (HeatBuffer, HeatDemand,
+                                                 HeatPipe, HeatSource, Node,
+                                                 Pump)
 
 
 class Model(_Model):

--- a/tests/models/simple_buffer/src/simple_buffer.py
+++ b/tests/models/simple_buffer/src/simple_buffer.py
@@ -1,19 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.csv_mixin import CSVMixin
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.component_type_mixin import ModelicaComponentTypeMixin
 from mesido.pycml.pycml_mixin import PyCMLMixin
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.csv_mixin import CSVMixin
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 if __name__ == "__main__":
     from model import Model

--- a/tests/models/source_pipe_sink/src/double_pipe_heat.py
+++ b/tests/models/source_pipe_sink/src/double_pipe_heat.py
@@ -1,3 +1,12 @@
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
@@ -5,17 +14,6 @@ from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.io.write_output import ScenarioOutput
-
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/source_pipe_split_sink/src/double_pipe_heat.py
+++ b/tests/models/source_pipe_split_sink/src/double_pipe_heat.py
@@ -1,15 +1,14 @@
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
+++ b/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
@@ -1,18 +1,16 @@
+import numpy as np
+from rtctools.data.storage import DataStore
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.data.storage import DataStore
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
 
 
 class TargetDemandGoal(Goal):
@@ -153,7 +151,9 @@ class HeatProblem(
 
 if __name__ == "__main__":
     import time
-    from mesido.workflows import EndScenarioSizingStaged, run_end_scenario_sizing
+
+    from mesido.workflows import (EndScenarioSizingStaged,
+                                  run_end_scenario_sizing)
 
     start_time = time.time()
 

--- a/tests/models/test_case_small_network_optional_assets_annualized/plot_discount.py
+++ b/tests/models/test_case_small_network_optional_assets_annualized/plot_discount.py
@@ -1,5 +1,4 @@
 import matplotlib.pyplot as plt
-
 import numpy as np
 
 

--- a/tests/models/test_case_small_network_optional_assets_annualized/src/run_annualized.py
+++ b/tests/models/test_case_small_network_optional_assets_annualized/src/run_annualized.py
@@ -1,18 +1,16 @@
 from typing import Any, Dict, List
 
 import esdl
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.workflows.goals.minimize_tco_goal import MinimizeTCO
 
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.util import run_optimization_problem
-
 try:
-    from models.test_case_small_network_optional_assets_annualized.src.run_ates import (
-        HeatProblem,
-    )
+    from models.test_case_small_network_optional_assets_annualized.src.run_ates import \
+        HeatProblem
 except ModuleNotFoundError:
     from run_ates import HeatProblem
 

--- a/tests/models/test_case_small_network_optional_assets_annualized/src/run_ates.py
+++ b/tests/models/test_case_small_network_optional_assets_annualized/src/run_ates.py
@@ -1,19 +1,17 @@
+import numpy as np
+from rtctools.data.storage import DataStore
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.data.storage import DataStore
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/test_case_small_network_with_ates/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates/src/run_ates.py
@@ -1,4 +1,13 @@
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import (
+    CachingQPSol, SinglePassGoalProgrammingMixin)
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
@@ -6,23 +15,7 @@ from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.utils.adapt_profiles import (
     adapt_hourly_profile_averages_timestep_size,
-    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day,
-)
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import (
-    CachingQPSol,
-    SinglePassGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
+    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day)
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/test_case_small_network_with_ates_with_buffer/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates_with_buffer/src/run_ates.py
@@ -1,21 +1,18 @@
 import esdl
+import numpy as np
+from rtctools.data.storage import DataStore
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.data.storage import DataStore
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases/case_1a/src/run_1a.py
+++ b/tests/models/unit_cases/case_1a/src/run_1a.py
@@ -1,20 +1,18 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.homotopy_mixin import HomotopyMixin
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
 from mesido.qth_not_maintained.qth_mixin import QTHMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.homotopy_mixin import HomotopyMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases/case_1a_t_var/src/run_1a.py
+++ b/tests/models/unit_cases/case_1a_t_var/src/run_1a.py
@@ -1,19 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases/case_2a/src/equal_temperatures.py
+++ b/tests/models/unit_cases/case_2a/src/equal_temperatures.py
@@ -1,18 +1,16 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.homotopy_mixin import HomotopyMixin
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.heat_mixin import HeatMixin
 from mesido.qth_mixin import QTHMixin
 from mesido.util import run_heat_network_optimization
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.homotopy_mixin import HomotopyMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases/case_2a/src/run_2a.py
+++ b/tests/models/unit_cases/case_2a/src/run_2a.py
@@ -1,21 +1,20 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.homotopy_mixin import HomotopyMixin
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
 from mesido.qth_not_maintained.qth_mixin import QTHMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.homotopy_mixin import HomotopyMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases/case_3a/src/run_3a.py
+++ b/tests/models/unit_cases/case_3a/src/run_3a.py
@@ -1,3 +1,13 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.homotopy_mixin import HomotopyMixin
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
@@ -5,18 +15,6 @@ from mesido.physics_mixin import PhysicsMixin
 from mesido.qth_not_maintained.qth_mixin import QTHMixin
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.goals.minimize_tco_goal import MinimizeTCO
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.homotopy_mixin import HomotopyMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases/case_3a_setpoint/src/run_3a.py
+++ b/tests/models/unit_cases/case_3a_setpoint/src/run_3a.py
@@ -1,19 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases_electricity/battery/src/example.py
+++ b/tests/models/unit_cases_electricity/battery/src/example.py
@@ -1,20 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases_electricity/bus_networks/src/example.py
+++ b/tests/models/unit_cases_electricity/bus_networks/src/example.py
@@ -1,20 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases_electricity/electrolyzer/src/example.py
+++ b/tests/models/unit_cases_electricity/electrolyzer/src/example.py
@@ -1,21 +1,18 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
+
 from mesido.electricity_physics_mixin import ElectrolyzerOption
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.network_common import NetworkSettings
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 class RevenueGoal(Goal):

--- a/tests/models/unit_cases_electricity/heat_pump_elec/src/run_hp_elec.py
+++ b/tests/models/unit_cases_electricity/heat_pump_elec/src/run_hp_elec.py
@@ -1,4 +1,12 @@
 import esdl
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import (Goal,
+                                                          GoalProgrammingMixin)
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
 from mesido.esdl.esdl_mixin import ESDLMixin
@@ -8,18 +16,6 @@ from mesido.head_loss_class import HeadLossOption
 from mesido.physics_mixin import PhysicsMixin
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.workflows.goals.minimize_tco_goal import MinimizeTCO
-
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMixin
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.util import run_optimization_problem
 
 
 # TODO: check if this run script is still valid as test case for electric heatpump and update with

--- a/tests/models/unit_cases_electricity/source_sink_cable/src/example.py
+++ b/tests/models/unit_cases_electricity/source_sink_cable/src/example.py
@@ -1,21 +1,18 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases_gas/multi_demand_source_node/src/run_test.py
+++ b/tests/models/unit_cases_gas/multi_demand_source_node/src/run_test.py
@@ -1,21 +1,18 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.physics_mixin import PhysicsMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases_gas/source_pipe_split_sink/src/run_source_sink.py
+++ b/tests/models/unit_cases_gas/source_pipe_split_sink/src/run_source_sink.py
@@ -1,20 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/unit_cases_gas/source_sink/src/run_source_sink.py
+++ b/tests/models/unit_cases_gas/source_sink/src/run_source_sink.py
@@ -1,20 +1,17 @@
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin import GoalProgrammingMixin
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
 
 
 class TargetDemandGoal(Goal):

--- a/tests/models/wko/src/example.py
+++ b/tests/models/wko/src/example.py
@@ -1,29 +1,24 @@
 import logging
 
 import casadi as ca
+import numpy as np
+from rtctools.optimization.collocated_integrated_optimization_problem import \
+    CollocatedIntegratedOptimizationProblem
+from rtctools.optimization.goal_programming_mixin_base import Goal
+from rtctools.optimization.linearized_order_goal_programming_mixin import \
+    LinearizedOrderGoalProgrammingMixin
+from rtctools.optimization.single_pass_goal_programming_mixin import \
+    SinglePassGoalProgrammingMixin
+from rtctools.optimization.timeseries import Timeseries
+from rtctools.util import run_optimization_problem
 
 from mesido.esdl.esdl_mixin import ESDLMixin
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.techno_economic_mixin import TechnoEconomicMixin
-from mesido.workflows.utils.error_types import (
-    HEAT_AND_COOL_NETWORK_ERRORS,
-    potential_error_to_error,
-)
-
-import numpy as np
-
-from rtctools.optimization.collocated_integrated_optimization_problem import (
-    CollocatedIntegratedOptimizationProblem,
-)
-from rtctools.optimization.goal_programming_mixin_base import Goal
-from rtctools.optimization.linearized_order_goal_programming_mixin import (
-    LinearizedOrderGoalProgrammingMixin,
-)
-from rtctools.optimization.single_pass_goal_programming_mixin import SinglePassGoalProgrammingMixin
-from rtctools.optimization.timeseries import Timeseries
-from rtctools.util import run_optimization_problem
+from mesido.workflows.utils.error_types import (HEAT_AND_COOL_NETWORK_ERRORS,
+                                                potential_error_to_error)
 
 logger = logging.getLogger("WarmingUP-MPC")
 logger.setLevel(logging.INFO)

--- a/tests/test_absolute_heat.py
+++ b/tests/test_absolute_heat.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
 
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestAbsoluteHeat(TestCase):

--- a/tests/test_asset_is_realized.py
+++ b/tests/test_asset_is_realized.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestAssetIsRealized(TestCase):
@@ -27,9 +27,8 @@ class TestAssetIsRealized(TestCase):
         - Check that the asset is not used before the asset_is_realized == 1
         """
         import models.test_case_small_network_with_ates.src.run_ates as run_ates
-        from models.test_case_small_network_with_ates.src.run_ates import (
-            HeatProblemPlacingOverTime,
-        )
+        from models.test_case_small_network_with_ates.src.run_ates import \
+            HeatProblemPlacingOverTime
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 

--- a/tests/test_ates.py
+++ b/tests/test_ates.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestAtes(TestCase):
@@ -25,9 +25,8 @@ class TestAtes(TestCase):
 
         """
         import models.test_case_small_network_with_ates.src.run_ates as run_ates
-        from models.test_case_small_network_with_ates.src.run_ates import (
-            HeatProblem,
-        )
+        from models.test_case_small_network_with_ates.src.run_ates import \
+            HeatProblem
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 

--- a/tests/test_cable_topology_optimization.py
+++ b/tests/test_cable_topology_optimization.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestElectricityTopo(TestCase):

--- a/tests/test_cold_demand.py
+++ b/tests/test_cold_demand.py
@@ -3,25 +3,20 @@ import unittest.mock
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+import pandas as pd
+from utils_test_scaling import create_log_list_scaling
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.exceptions import MesidoAssetIssueError
 from mesido.potential_errors import MesidoAssetIssueType, PotentialErrors
 from mesido.util import run_esdl_mesido_optimization
-from mesido.workflows.utils.adapt_profiles import (
-    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day,
-)
+from mesido.workflows.utils.adapt_profiles import \
+    adapt_hourly_year_profile_to_day_averaged_with_hourly_peak_day
 from mesido.workflows.utils.error_types import mesido_issue_type_gen_message
-
-
-import numpy as np
-
-import pandas as pd
-
-from utils_test_scaling import create_log_list_scaling
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
-
 
 logger = logging.getLogger("WarmingUP-MPC")
 logger.setLevel(logging.INFO)

--- a/tests/test_elec_boiler.py
+++ b/tests/test_elec_boiler.py
@@ -1,18 +1,14 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test,
+                         electric_power_conservation_test,
+                         energy_conservation_test, heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import (
-    demand_matching_test,
-    electric_power_conservation_test,
-    energy_conservation_test,
-    heat_to_discharge_test,
-)
 
 
 class TestElecBoiler(TestCase):

--- a/tests/test_electric_bus.py
+++ b/tests/test_electric_bus.py
@@ -10,13 +10,12 @@ What at least was implement
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import electric_power_conservation_test
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import electric_power_conservation_test
 
 
 class TestMILPbus(TestCase):
@@ -34,7 +33,8 @@ class TestMILPbus(TestCase):
 
         """
         import models.unit_cases_electricity.bus_networks.src.example as example
-        from models.unit_cases_electricity.bus_networks.src.example import ElectricityProblem
+        from models.unit_cases_electricity.bus_networks.src.example import \
+            ElectricityProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -89,7 +89,8 @@ class TestMILPbus(TestCase):
 
         """
         import models.unit_cases_electricity.bus_networks.src.example as example
-        from models.unit_cases_electricity.bus_networks.src.example import ElectricityProblem
+        from models.unit_cases_electricity.bus_networks.src.example import \
+            ElectricityProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_electric_source_sink.py
+++ b/tests/test_electric_source_sink.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import electric_power_conservation_test
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import electric_power_conservation_test
-
 
 # TODO: still have to make test where elecitricity direction is switched:
 # e.g. 2 nodes, with at each node a producer and consumer, first one node medium demand, second
@@ -32,7 +30,8 @@ class TestMILPElectricSourceSink(TestCase):
         """
 
         import models.unit_cases_electricity.source_sink_cable.src.example as example
-        from models.unit_cases_electricity.source_sink_cable.src.example import ElectricityProblem
+        from models.unit_cases_electricity.source_sink_cable.src.example import \
+            ElectricityProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
         tol = 1e-10
@@ -113,9 +112,8 @@ class TestMILPElectricSourceSink(TestCase):
         """
 
         import models.unit_cases_electricity.source_sink_cable.src.example as example
-        from models.unit_cases_electricity.source_sink_cable.src.example import (
-            ElectricityProblemMaxCurr,
-        )
+        from models.unit_cases_electricity.source_sink_cable.src.example import \
+            ElectricityProblemMaxCurr
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -204,9 +202,8 @@ class TestMILPElectricSourceSink(TestCase):
         """
 
         import models.unit_cases_electricity.source_sink_cable.src.example as example
-        from models.unit_cases_electricity.source_sink_cable.src.example import (
-            ElectricityProblem,
-        )
+        from models.unit_cases_electricity.source_sink_cable.src.example import \
+            ElectricityProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_electricity_storage.py
+++ b/tests/test_electricity_storage.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test,
+                         electric_power_conservation_test, feasibility_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, electric_power_conservation_test, feasibility_test
 
 
 class TestMILPElectricSourceSink(TestCase):
@@ -27,7 +27,8 @@ class TestMILPElectricSourceSink(TestCase):
         """
 
         import models.unit_cases_electricity.battery.src.example as example
-        from models.unit_cases_electricity.battery.src.example import ElectricityProblem
+        from models.unit_cases_electricity.battery.src.example import \
+            ElectricityProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
         tol = 1e-10

--- a/tests/test_electrolyzer.py
+++ b/tests/test_electrolyzer.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 import mesido._darcy_weisbach as darcy_weisbach
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.network_common import NetworkSettings
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestElectrolyzer(TestCase):
@@ -27,7 +27,8 @@ class TestElectrolyzer(TestCase):
         - The pipe head loss constraint for a hydrogen network
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import MILPProblemInequality
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemInequality
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -246,7 +247,8 @@ class TestElectrolyzer(TestCase):
 
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import MILPProblemInequality
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemInequality
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -326,9 +328,8 @@ class TestElectrolyzer(TestCase):
 
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import (
-            MILPProblemConstantEfficiency,
-        )
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemConstantEfficiency
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -377,9 +378,8 @@ class TestElectrolyzer(TestCase):
 
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import (
-            MILPProblemEquality,
-        )
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemEquality
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -456,9 +456,8 @@ class TestElectrolyzer(TestCase):
 
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import (
-            MILPProblemEquality,
-        )
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemEquality
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_emerge.py
+++ b/tests/test_emerge.py
@@ -16,6 +16,7 @@ class TestEmerge(TestCase):
 
         """
         import models.emerge.src.example as example
+
         from mesido.workflows.emerge import EmergeWorkFlow
 
         base_folder = Path(example.__file__).resolve().parent.parent

--- a/tests/test_end_scenario_sizing.py
+++ b/tests/test_end_scenario_sizing.py
@@ -2,23 +2,16 @@ from pathlib import Path
 from unittest import TestCase
 
 import esdl
+import numpy as np
+from rtctools.util import run_optimization_problem
+from utils_tests import demand_matching_test
 
 import mesido._darcy_weisbach as darcy_weisbach
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
-from mesido.workflows import (
-    EndScenarioSizing,
-    EndScenarioSizingDiscounted,
-    EndScenarioSizingStaged,
-    run_end_scenario_sizing,
-)
+from mesido.workflows import (EndScenarioSizing, EndScenarioSizingDiscounted,
+                              EndScenarioSizingStaged, run_end_scenario_sizing)
 from mesido.workflows.grow_workflow import EndScenarioSizingHeadLossStaged
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
-
-from utils_tests import demand_matching_test
 
 
 class TestEndScenarioSizing(TestCase):

--- a/tests/test_end_scenario_sizing_annualized.py
+++ b/tests/test_end_scenario_sizing_annualized.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
 
 
 class TestEndScenarioSizingAnnualized(TestCase):
@@ -24,17 +23,15 @@ class TestEndScenarioSizingAnnualized(TestCase):
     """
 
     def test_end_scenario_sizing_annualized(self):
-        from models.test_case_small_network_optional_assets_annualized.src.run_ates import (
-            HeatProblem,
-        )
+        from models.test_case_small_network_optional_assets_annualized.src import \
+            run_annualized
         from models.test_case_small_network_optional_assets_annualized.src.run_annualized import (
             HeatProblemDiscAnnualizedCost,
-            HeatProblemDiscAnnualizedCostModifiedParam,
             HeatProblemDiscAnnualizedCostModifiedDiscountRate,
-        )
-        from models.test_case_small_network_optional_assets_annualized.src import (
-            run_annualized,
-        )
+            HeatProblemDiscAnnualizedCostModifiedParam)
+        from models.test_case_small_network_optional_assets_annualized.src.run_ates import \
+            HeatProblem
+
         from mesido.financial_mixin import calculate_annuity_factor
 
         base_folder = Path(run_annualized.__file__).resolve().parent.parent

--- a/tests/test_esdl_parsing.py
+++ b/tests/test_esdl_parsing.py
@@ -1,12 +1,11 @@
 import unittest
 from pathlib import Path
 
+import numpy as np
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_parser import ESDLFileParser, ESDLStringParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
 
 
 class TestESDLParsing(unittest.TestCase):
@@ -18,7 +17,8 @@ class TestESDLParsing(unittest.TestCase):
         from using either the file or the string as input are the same.
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import MILPProblemInequality
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemInequality
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_esdl_pycml.py
+++ b/tests/test_esdl_pycml.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from rtctools.util import run_optimization_problem
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
 
 
 class TestESDL(TestCase):
@@ -20,7 +19,8 @@ class TestESDL(TestCase):
 
         """
         import models.basic_source_and_demand.src.heat_comparison as heat_comparison
-        from models.basic_source_and_demand.src.heat_comparison import HeatESDL, HeatPython
+        from models.basic_source_and_demand.src.heat_comparison import (
+            HeatESDL, HeatPython)
 
         base_folder = Path(heat_comparison.__file__).resolve().parent.parent
         input_folder = base_folder / "input"

--- a/tests/test_gas_boiler.py
+++ b/tests/test_gas_boiler.py
@@ -2,13 +2,13 @@ import math
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestGasBoiler(TestCase):

--- a/tests/test_gas_electricity.py
+++ b/tests/test_gas_electricity.py
@@ -1,21 +1,17 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test,
+                         electric_power_conservation_test,
+                         energy_conservation_test, gas_pipes_head_loss_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.asset_to_component_base import _AssetToComponentBase
 from mesido.esdl.edr_pipe_class import EDRGasPipeClass
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.workflows.utils.helpers import run_optimization_problem_solver
-
-import numpy as np
-
-from utils_tests import (
-    demand_matching_test,
-    electric_power_conservation_test,
-    energy_conservation_test,
-    gas_pipes_head_loss_test,
-    heat_to_discharge_test,
-)
 
 
 class TestGasElect(TestCase):
@@ -45,7 +41,8 @@ class TestGasElect(TestCase):
         6. manually calculated TCO is equal to Objective function value
         """
         import models.gas_electricity_network.src.run_gas_elect as example
-        from models.gas_electricity_network.src.run_gas_elect import GasElectProblem
+        from models.gas_electricity_network.src.run_gas_elect import \
+            GasElectProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_gas_multi_demand_source_node.py
+++ b/tests/test_gas_multi_demand_source_node.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestMILPGasMultiDemandSourceNode(TestCase):
@@ -22,7 +22,8 @@ class TestMILPGasMultiDemandSourceNode(TestCase):
 
         """
         import models.unit_cases_gas.multi_demand_source_node.src.run_test as example
-        from models.unit_cases_gas.multi_demand_source_node.src.run_test import GasProblem
+        from models.unit_cases_gas.multi_demand_source_node.src.run_test import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_gas_pipe_topology_optimization.py
+++ b/tests/test_gas_pipe_topology_optimization.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestGasNetwork(TestCase):

--- a/tests/test_gas_source_sink.py
+++ b/tests/test_gas_source_sink.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestMILPGasSourceSink(TestCase):
@@ -20,7 +20,8 @@ class TestMILPGasSourceSink(TestCase):
 
         """
         import models.unit_cases_gas.source_sink.src.run_source_sink as example
-        from models.unit_cases_gas.source_sink.src.run_source_sink import GasProblem
+        from models.unit_cases_gas.source_sink.src.run_source_sink import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_head_loss.py
+++ b/tests/test_head_loss.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import demand_matching_test
+
 import mesido._darcy_weisbach as darcy_weisbach
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.esdl.esdl_parser import ESDLFileParser
@@ -8,10 +11,6 @@ from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.network_common import NetworkSettings
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test
 
 
 class TestHeadLoss(TestCase):
@@ -249,7 +248,8 @@ class TestHeadLoss(TestCase):
             - LINEARIZED_N_LINES_EQUALITY: velo > min velocity
         """
         import models.source_pipe_split_sink.src.double_pipe_heat as example
-        from models.source_pipe_split_sink.src.double_pipe_heat import SourcePipeSink
+        from models.source_pipe_split_sink.src.double_pipe_heat import \
+            SourcePipeSink
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -480,7 +480,8 @@ class TestHeadLoss(TestCase):
         """
 
         import models.unit_cases_gas.source_sink.src.run_source_sink as example
-        from models.unit_cases_gas.source_sink.src.run_source_sink import GasProblem
+        from models.unit_cases_gas.source_sink.src.run_source_sink import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -642,7 +643,8 @@ class TestHeadLoss(TestCase):
         """
 
         import models.unit_cases_gas.source_pipe_split_sink.src.run_source_sink as example
-        from models.unit_cases_gas.source_pipe_split_sink.src.run_source_sink import GasProblem
+        from models.unit_cases_gas.source_pipe_split_sink.src.run_source_sink import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -808,7 +810,8 @@ class TestHeadLoss(TestCase):
         _ That the pipes have the expected head loss given their reference pressures
         """
         import models.multiple_gas_carriers.src.run_multiple_gas_carriers as example
-        from models.multiple_gas_carriers.src.run_multiple_gas_carriers import GasProblem
+        from models.multiple_gas_carriers.src.run_multiple_gas_carriers import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -857,7 +860,8 @@ class TestHeadLoss(TestCase):
         _ That the pipes have the expected head loss given their reference pressures
         """
         import models.multiple_gas_carriers.src.run_multiple_gas_carriers as example
-        from models.multiple_gas_carriers.src.run_multiple_gas_carriers import GasProblem
+        from models.multiple_gas_carriers.src.run_multiple_gas_carriers import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_head_loss_class.py
+++ b/tests/test_head_loss_class.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from rtctools.util import run_optimization_problem
+
 from mesido.head_loss_class import HeadLossOption
 from mesido.network_common import NetworkSettings
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
 
 
 class TestHeadLossCalculation(TestCase):
@@ -21,7 +20,8 @@ class TestHeadLossCalculation(TestCase):
         Check whether the returned scalar had the expected value.
         """
         import models.basic_source_and_demand.src.heat_comparison as heat_comparison
-        from models.basic_source_and_demand.src.heat_comparison import HeatPython
+        from models.basic_source_and_demand.src.heat_comparison import \
+            HeatPython
 
         class Model(HeatPython):
             def __init__(self, head_loss_option, *args, **kwargs):

--- a/tests/test_heat.py
+++ b/tests/test_heat.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestHeat(TestCase):

--- a/tests/test_heat_loss_u_values.py
+++ b/tests/test_heat_loss_u_values.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
-from mesido._heat_loss_u_values_pipe import heat_loss_u_values_pipe
-
 import numpy as np
+
+from mesido._heat_loss_u_values_pipe import heat_loss_u_values_pipe
 
 
 class TestHeatLossUValues(TestCase):

--- a/tests/test_hydraulic_power.py
+++ b/tests/test_hydraulic_power.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+import pandas as pd
+from utils_tests import demand_matching_test
+
 from mesido._darcy_weisbach import head_loss
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.esdl.esdl_parser import ESDLFileParser
@@ -8,12 +12,6 @@ from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.network_common import NetworkSettings
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-import pandas as pd
-
-from utils_tests import demand_matching_test
 
 
 class TestHydraulicPower(TestCase):
@@ -53,9 +51,7 @@ class TestHydraulicPower(TestCase):
 
         """
         import models.pipe_test.src.run_hydraulic_power as run_hydraulic_power
-        from models.pipe_test.src.run_hydraulic_power import (
-            HeatProblem,
-        )
+        from models.pipe_test.src.run_hydraulic_power import HeatProblem
 
         # Settings
         base_folder = Path(run_hydraulic_power.__file__).resolve().parent.parent
@@ -278,9 +274,8 @@ class TestHydraulicPower(TestCase):
         - demand matching
         """
         import models.unit_cases_gas.source_sink.src.run_source_sink as run_source_sink
-        from models.unit_cases_gas.source_sink.src.run_source_sink import (
-            GasProblem,
-        )
+        from models.unit_cases_gas.source_sink.src.run_source_sink import \
+            GasProblem
 
         # Settings
         base_folder = Path(run_source_sink.__file__).resolve().parent.parent
@@ -408,9 +403,8 @@ class TestHydraulicPower(TestCase):
         - checks if differences of in/out port is equal to the added hydraulic power of that pipe
         """
         import models.unit_cases_gas.multi_demand_source_node.src.run_test as run_test
-        from models.unit_cases_gas.multi_demand_source_node.src.run_test import (
-            GasProblem,
-        )
+        from models.unit_cases_gas.multi_demand_source_node.src.run_test import \
+            GasProblem
 
         # Settings
         base_folder = Path(run_test.__file__).resolve().parent.parent

--- a/tests/test_insulation.py
+++ b/tests/test_insulation.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
 
 
 class TestInsulation(TestCase):

--- a/tests/test_logical_links.py
+++ b/tests/test_logical_links.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestLogicalLinks(TestCase):
@@ -22,7 +22,8 @@ class TestLogicalLinks(TestCase):
 
         """
         import models.unit_cases_electricity.bus_networks.src.example as example
-        from models.unit_cases_electricity.bus_networks.src.example import ElectricityProblem
+        from models.unit_cases_electricity.bus_networks.src.example import \
+            ElectricityProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -54,7 +55,8 @@ class TestLogicalLinks(TestCase):
 
         """
         import models.unit_cases_gas.multi_demand_source_node.src.run_test as example
-        from models.unit_cases_gas.multi_demand_source_node.src.run_test import GasProblem
+        from models.unit_cases_gas.multi_demand_source_node.src.run_test import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -84,7 +86,8 @@ class TestLogicalLinks(TestCase):
         """
 
         import models.unit_cases_gas.source_pipe_split_sink.src.run_source_sink as example
-        from models.unit_cases_gas.source_pipe_split_sink.src.run_source_sink import GasProblem
+        from models.unit_cases_gas.source_pipe_split_sink.src.run_source_sink import \
+            GasProblem
 
         base_folder = Path(example.__file__).resolve().parent.parent
 
@@ -126,7 +129,8 @@ class TestLogicalLinks(TestCase):
         """
 
         import models.source_pipe_split_sink.src.double_pipe_heat as example
-        from models.source_pipe_split_sink.src.double_pipe_heat import SourcePipeSink
+        from models.source_pipe_split_sink.src.double_pipe_heat import \
+            SourcePipeSink
 
         base_folder = Path(example.__file__).resolve().parent.parent
 

--- a/tests/test_max_size_and_optional_assets.py
+++ b/tests/test_max_size_and_optional_assets.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestMaxSizeAggregationCount(TestCase):
@@ -37,9 +37,8 @@ class TestMaxSizeAggregationCount(TestCase):
 
         """
         import models.test_case_small_network_with_ates_with_buffer.src.run_ates as run_ates
-        from models.test_case_small_network_with_ates_with_buffer.src.run_ates import (
-            HeatProblem,
-        )
+        from models.test_case_small_network_with_ates_with_buffer.src.run_ates import \
+            HeatProblem
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 
@@ -135,9 +134,8 @@ class TestMaxSizeAggregationCount(TestCase):
         np.testing.assert_allclose(results["HeatStorage_74c1_aggregation_count"], 1.0)
 
         import models.test_case_small_network_ates_buffer_optional_assets.src.run_ates as run_ates
-        from models.test_case_small_network_ates_buffer_optional_assets.src.run_ates import (
-            HeatProblem,
-        )
+        from models.test_case_small_network_ates_buffer_optional_assets.src.run_ates import \
+            HeatProblem
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 

--- a/tests/test_multicommodity.py
+++ b/tests/test_multicommodity.py
@@ -1,18 +1,14 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test,
+                         electric_power_conservation_test,
+                         energy_conservation_test, heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import (
-    demand_matching_test,
-    electric_power_conservation_test,
-    energy_conservation_test,
-    heat_to_discharge_test,
-)
 
 
 class TestMultiCommodityHeatPump(TestCase):
@@ -33,7 +29,8 @@ class TestMultiCommodityHeatPump(TestCase):
 
         """
         import models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec as run_hp_elec
-        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import HeatProblem2
+        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import \
+            HeatProblem2
 
         base_folder = Path(run_hp_elec.__file__).resolve().parent.parent
 
@@ -103,7 +100,8 @@ class TestMultiCommodityHeatPump(TestCase):
 
         """
         import models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec as run_hp_elec
-        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import HeatProblem
+        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import \
+            HeatProblem
 
         base_folder = Path(run_hp_elec.__file__).resolve().parent.parent
 
@@ -173,9 +171,8 @@ class TestMultiCommodityHeatPump(TestCase):
 
         """
         import models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec as run_hp_elec
-        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import (
-            ElectricityProblem,
-        )
+        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import \
+            ElectricityProblem
 
         base_folder = Path(run_hp_elec.__file__).resolve().parent.parent
 
@@ -228,9 +225,8 @@ class TestMultiCommodityHeatPump(TestCase):
 
         """
         import models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec as run_hp_elec
-        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import (
-            ElectricityProblem,
-        )
+        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import \
+            ElectricityProblem
 
         base_folder = Path(run_hp_elec.__file__).resolve().parent.parent
 
@@ -273,9 +269,8 @@ class TestMultiCommodityHeatPump(TestCase):
 
         """
         import models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec as run_hp_elec
-        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import (
-            ElectricityProblemPriceProfile,
-        )
+        from models.unit_cases_electricity.heat_pump_elec.src.run_hp_elec import \
+            ElectricityProblemPriceProfile
 
         base_folder = Path(run_hp_elec.__file__).resolve().parent.parent
 

--- a/tests/test_multicommodity_simulator.py
+++ b/tests/test_multicommodity_simulator.py
@@ -1,29 +1,22 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from rtctools.util import run_optimization_problem
+from utils_test_scaling import (create_problem_with_debug_info,
+                                problem_scaling_check)
+from utils_tests import (demand_matching_test,
+                         electric_power_conservation_test,
+                         energy_conservation_test, feasibility_test)
+
 import mesido._darcy_weisbach as darcy_weisbach
 from mesido.electricity_physics_mixin import ElectrolyzerOption
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.network_common import NetworkSettings
 from mesido.workflows.multicommodity_simulator_workflow import (
-    MultiCommoditySimulator,
-    MultiCommoditySimulatorNoLosses,
-    run_sequatially_staged_simulation,
-)
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
-
-from utils_test_scaling import create_problem_with_debug_info, problem_scaling_check
-
-from utils_tests import (
-    demand_matching_test,
-    electric_power_conservation_test,
-    energy_conservation_test,
-    feasibility_test,
-)
+    MultiCommoditySimulator, MultiCommoditySimulatorNoLosses,
+    run_sequatially_staged_simulation)
 
 
 def check_electrolyzer_efficiency(tol, electrolyzer_gas, electrolyzer_power, esdl_electrolyzer):

--- a/tests/test_multiple_carriers.py
+++ b/tests/test_multiple_carriers.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
 
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestMultipleCarriers(TestCase):
@@ -19,9 +20,8 @@ class TestMultipleCarriers(TestCase):
 
         """
         import models.multiple_carriers.src.run_multiple_carriers as run_multiple_carriers
-        from models.multiple_carriers.src.run_multiple_carriers import (
-            HeatProblem,
-        )
+        from models.multiple_carriers.src.run_multiple_carriers import \
+            HeatProblem
 
         base_folder = Path(run_multiple_carriers.__file__).resolve().parent.parent
 

--- a/tests/test_multiple_in_and_out_port_components.py
+++ b/tests/test_multiple_in_and_out_port_components.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestHEX(TestCase):
@@ -27,9 +27,7 @@ class TestHEX(TestCase):
 
         """
         import models.heat_exchange.src.run_heat_exchanger as run_heat_exchanger
-        from models.heat_exchange.src.run_heat_exchanger import (
-            HeatProblem,
-        )
+        from models.heat_exchange.src.run_heat_exchanger import HeatProblem
 
         base_folder = Path(run_heat_exchanger.__file__).resolve().parent.parent
         # -----------------------------------------------------------------------------------------
@@ -127,9 +125,7 @@ class TestHEX(TestCase):
         both supply and return on one side have the same temperature.
         """
         import models.heat_exchange.src.run_heat_exchanger as run_heat_exchanger
-        from models.heat_exchange.src.run_heat_exchanger import (
-            HeatProblem,
-        )
+        from models.heat_exchange.src.run_heat_exchanger import HeatProblem
 
         base_folder = Path(run_heat_exchanger.__file__).resolve().parent.parent
 
@@ -197,9 +193,7 @@ class TestHEX(TestCase):
         """
 
         import models.heat_exchange.src.run_heat_exchanger as run_heat_exchanger
-        from models.heat_exchange.src.run_heat_exchanger import (
-            HeatProblem,
-        )
+        from models.heat_exchange.src.run_heat_exchanger import HeatProblem
 
         base_folder = Path(run_heat_exchanger.__file__).resolve().parent.parent
 
@@ -319,9 +313,7 @@ class TestHP(TestCase):
 
         """
         import models.heatpump.src.run_heat_pump as run_heat_pump
-        from models.heatpump.src.run_heat_pump import (
-            HeatProblem,
-        )
+        from models.heatpump.src.run_heat_pump import HeatProblem
 
         base_folder = Path(run_heat_pump.__file__).resolve().parent.parent
 

--- a/tests/test_network_simulator.py
+++ b/tests/test_network_simulator.py
@@ -1,15 +1,14 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from rtctools.util import run_optimization_problem
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.workflows import NetworkSimulatorHIGHSTestCase
-
-import numpy as np
-
-from rtctools.util import run_optimization_problem
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestNetworkSimulator(TestCase):

--- a/tests/test_pipe_diameter_sizing.py
+++ b/tests/test_pipe_diameter_sizing.py
@@ -2,14 +2,14 @@ import sys
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido._darcy_weisbach import friction_factor
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestPipeDiameterSizingExample(TestCase):
@@ -37,9 +37,8 @@ class TestPipeDiameterSizingExample(TestCase):
         sys.path.insert(1, root_folder)
 
         import examples.pipe_diameter_sizing.src.example  # noqa: E402, I100
-        from examples.pipe_diameter_sizing.src.example import (
-            PipeDiameterSizingProblem,
-        )  # noqa: E402, I100
+        from examples.pipe_diameter_sizing.src.example import \
+            PipeDiameterSizingProblem  # noqa: E402, I100
 
         base_folder = (
             Path(examples.pipe_diameter_sizing.src.example.__file__).resolve().parent.parent

--- a/tests/test_potential_errors.py
+++ b/tests/test_potential_errors.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from typing import Optional
 
 import esdl
+import numpy as np
+import pandas as pd
+from utils_test_scaling import create_log_list_scaling
 
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import InfluxDBProfileReader
@@ -12,12 +15,6 @@ from mesido.exceptions import MesidoAssetIssueError
 from mesido.potential_errors import MesidoAssetIssueType, PotentialErrors
 from mesido.workflows import EndScenarioSizingStaged
 from mesido.workflows.utils.error_types import mesido_issue_type_gen_message
-
-import numpy as np
-
-import pandas as pd
-
-from utils_test_scaling import create_log_list_scaling
 
 
 class MockInfluxDBProfileReader(InfluxDBProfileReader):

--- a/tests/test_producer_profiles.py
+++ b/tests/test_producer_profiles.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestProducerMaxProfile(TestCase):
@@ -76,9 +76,7 @@ class TestProducerMaxProfile(TestCase):
 
         import models.unit_cases.case_3a.src.run_3a as run_3a
         from models.unit_cases.case_3a.src.run_3a import (
-            HeatProblemESDLProdProfile,
-            HeatProblemESDLProdProfileTCO,
-        )
+            HeatProblemESDLProdProfile, HeatProblemESDLProdProfileTCO)
 
         base_folder = Path(run_3a.__file__).resolve().parent.parent
 
@@ -156,7 +154,8 @@ class TestProducerMaxProfile(TestCase):
         """
 
         import models.unit_cases.case_3a.src.run_3a as run_3a
-        from models.unit_cases.case_3a.src.run_3a import HeatProblemESDLProdProfile
+        from models.unit_cases.case_3a.src.run_3a import \
+            HeatProblemESDLProdProfile
 
         base_folder = Path(run_3a.__file__).resolve().parent.parent
 

--- a/tests/test_profile_parsing.py
+++ b/tests/test_profile_parsing.py
@@ -6,18 +6,16 @@ from pathlib import Path
 from typing import Optional
 
 import esdl
+import numpy as np
+import pandas as pd
 
 from mesido.esdl.esdl_parser import ESDLFileParser
-from mesido.esdl.profile_parser import InfluxDBProfileReader, ProfileReaderFromFile
+from mesido.esdl.profile_parser import (InfluxDBProfileReader,
+                                        ProfileReaderFromFile)
 from mesido.workflows import EndScenarioSizingStaged
 from mesido.workflows.utils.adapt_profiles import (
     adapt_hourly_profile_averages_timestep_size,
-    adapt_profile_to_copy_for_number_of_years,
-)
-
-import numpy as np
-
-import pandas as pd
+    adapt_profile_to_copy_for_number_of_years)
 
 
 class MockInfluxDBProfileReader(InfluxDBProfileReader):
@@ -174,7 +172,8 @@ class TestProfileLoading(unittest.TestCase):
         default UTC timezone has been set.
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import MILPProblemInequality
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemInequality
 
         base_folder = Path(example.__file__).resolve().parent.parent
         model_folder = base_folder / "model"
@@ -245,7 +244,8 @@ class TestProfileLoading(unittest.TestCase):
         if the loaded profiles match those specified in the csv.
         """
         import models.unit_cases_electricity.electrolyzer.src.example as example
-        from models.unit_cases_electricity.electrolyzer.src.example import MILPProblemInequality
+        from models.unit_cases_electricity.electrolyzer.src.example import \
+            MILPProblemInequality
 
         base_folder = Path(example.__file__).resolve().parent.parent
         model_folder = base_folder / "model"

--- a/tests/test_pycml.py
+++ b/tests/test_pycml.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
-from mesido.pycml import Model, Variable
-
 import numpy as np
+
+from mesido.pycml import Model, Variable
 
 
 class TestPyCML(TestCase):

--- a/tests/test_setpoint_constraints.py
+++ b/tests/test_setpoint_constraints.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+import pytest
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-import pytest
 
 
 class TestSetpointConstraints(TestCase):
@@ -26,7 +25,8 @@ class TestSetpointConstraints(TestCase):
 
         """
         import models.unit_cases.case_3a.src.run_3a as run_3a
-        from models.unit_cases.case_3a.src.run_3a import HeatProblemSetPointConstraints
+        from models.unit_cases.case_3a.src.run_3a import \
+            HeatProblemSetPointConstraints
 
         base_folder = Path(run_3a.__file__).resolve().parent.parent
 
@@ -109,7 +109,8 @@ class TestSetpointConstraints(TestCase):
 
         """
         import models.test_case_small_network_with_ates.src.run_ates as run_ates
-        from models.test_case_small_network_with_ates.src.run_ates import HeatProblemSetPoints
+        from models.test_case_small_network_with_ates.src.run_ates import \
+            HeatProblemSetPoints
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 
@@ -145,7 +146,8 @@ class TestSetpointConstraints(TestCase):
 
         """
         import models.test_case_small_network_with_ates.src.run_ates as run_ates
-        from models.test_case_small_network_with_ates.src.run_ates import HeatProblemSetPoints
+        from models.test_case_small_network_with_ates.src.run_ates import \
+            HeatProblemSetPoints
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 
@@ -180,7 +182,8 @@ class TestSetpointConstraints(TestCase):
 
         """
         import models.test_case_small_network_with_ates.src.run_ates as run_ates
-        from models.test_case_small_network_with_ates.src.run_ates import HeatProblemSetPoints
+        from models.test_case_small_network_with_ates.src.run_ates import \
+            HeatProblemSetPoints
 
         base_folder = Path(run_ates.__file__).resolve().parent.parent
 

--- a/tests/test_temperature_ates_hp.py
+++ b/tests/test_temperature_ates_hp.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestAtesTemperature(TestCase):
@@ -37,7 +37,8 @@ class TestAtesTemperature(TestCase):
         - heat loss ates>= relation of heat loss
         """
         import models.ates_temperature.src.run_ates_temperature as run_ates_temperature
-        from models.ates_temperature.src.run_ates_temperature import HeatProblem
+        from models.ates_temperature.src.run_ates_temperature import \
+            HeatProblem
 
         basefolder = Path(run_ates_temperature.__file__).resolve().parent.parent
 
@@ -151,7 +152,8 @@ class TestAtesTemperature(TestCase):
         """
 
         import models.ates_temperature.src.run_ates_temperature as run_ates_temperature
-        from models.ates_temperature.src.run_ates_temperature import HeatProblemMaxFlow
+        from models.ates_temperature.src.run_ates_temperature import \
+            HeatProblemMaxFlow
 
         basefolder = Path(run_ates_temperature.__file__).resolve().parent.parent
 

--- a/tests/test_topo_constraints.py
+++ b/tests/test_topo_constraints.py
@@ -3,15 +3,15 @@ from pathlib import Path
 from typing import Dict
 from unittest import TestCase
 
+import numpy as np
+import numpy.testing
+
 from mesido._heat_loss_u_values_pipe import pipe_heat_loss
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.pipe_class import PipeClass
 from mesido.techno_economic_mixin import TechnoEconomicMixin
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-import numpy.testing
 
 MIP_TOLERANCE = 1e-8
 
@@ -30,9 +30,8 @@ class TestTopoConstraintsOnPipeDiameterSizingExample(TestCase):
         sys.path.insert(1, root_folder)
 
         import examples.pipe_diameter_sizing.src.example  # noqa: E402, I100
-        from examples.pipe_diameter_sizing.src.example import (
-            PipeDiameterSizingProblem,
-        )  # noqa: E402, I100
+        from examples.pipe_diameter_sizing.src.example import \
+            PipeDiameterSizingProblem  # noqa: E402, I100
 
         base_folder = (
             Path(examples.pipe_diameter_sizing.src.example.__file__).resolve().parent.parent

--- a/tests/test_updated_esdl_post_process.py
+++ b/tests/test_updated_esdl_post_process.py
@@ -5,13 +5,11 @@ from pathlib import Path
 from unittest import TestCase
 
 import esdl
+import numpy as np
 from esdl.esdl_handler import EnergySystemHandler
 
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.workflows import EndScenarioSizingStaged
-
-
-import numpy as np
 
 
 class TestUpdatedESDL(TestCase):

--- a/tests/test_updated_esdl_pre_process.py
+++ b/tests/test_updated_esdl_pre_process.py
@@ -2,14 +2,14 @@ import sys
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_test_scaling import \
+    create_problem_with_debug_info  # , problem_scaling_check
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.workflows import run_end_scenario_sizing
-
-import numpy as np
-
-from utils_test_scaling import create_problem_with_debug_info  # , problem_scaling_check
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestUpdatedESDL(TestCase):
@@ -32,7 +32,8 @@ class TestUpdatedESDL(TestCase):
         sys.path.insert(1, root_folder)
 
         import examples.PoCTutorial.src.run_grow_tutorial
-        from examples.PoCTutorial.src.run_grow_tutorial import EndScenarioSizingStagedHighs
+        from examples.PoCTutorial.src.run_grow_tutorial import \
+            EndScenarioSizingStagedHighs
 
         base_folder = (
             Path(examples.PoCTutorial.src.run_grow_tutorial.__file__).resolve().parent.parent

--- a/tests/test_validation_pandapipes.py
+++ b/tests/test_validation_pandapipes.py
@@ -3,24 +3,20 @@ import sys
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+import pandapipes as pp
+import pandapower.control as control
+import pandas as pd
+from pandapipes.timeseries import run_timeseries
+from pandapower.timeseries import DFData, OutputWriter
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.head_loss_class import HeadLossOption
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-import pandapipes as pp
-from pandapipes.timeseries import run_timeseries
-
-import pandapower.control as control
-from pandapower.timeseries import DFData
-from pandapower.timeseries import OutputWriter
-
-import pandas as pd
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class ValidateWithPandaPipes(TestCase):
@@ -94,7 +90,8 @@ class ValidateWithPandaPipes(TestCase):
         # Setup and run pandapipes
         # ------------------------------------------------------------------------------
         # ------------------------------------------------------------------------------
-        from examples.pandapipes.src.pandapipeesdlparser import PandapipeEsdlParserClass
+        from examples.pandapipes.src.pandapipeesdlparser import \
+            PandapipeEsdlParserClass
 
         esdl_file = os.path.join(base_folder, "model", "Test_Tree_S1C1.esdl")
         esdlparser = PandapipeEsdlParserClass()

--- a/tests/test_varying_temperature.py
+++ b/tests/test_varying_temperature.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido._heat_loss_u_values_pipe import pipe_heat_loss
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestVaryingTemperature(TestCase):
@@ -294,7 +294,8 @@ class TestVaryingTemperature(TestCase):
 
         """
         import models.heat_exchange.src.run_heat_exchanger as run_heat_exchanger
-        from models.heat_exchange.src.run_heat_exchanger import HeatProblemTvarDisableHEX
+        from models.heat_exchange.src.run_heat_exchanger import \
+            HeatProblemTvarDisableHEX
 
         base_folder = Path(run_heat_exchanger.__file__).resolve().parent.parent
 
@@ -336,7 +337,8 @@ class TestVaryingTemperature(TestCase):
 
         """
         import models.heat_exchange.src.run_heat_exchanger as run_heat_exchanger
-        from models.heat_exchange.src.run_heat_exchanger import HeatProblemTvarSecondary
+        from models.heat_exchange.src.run_heat_exchanger import \
+            HeatProblemTvarSecondary
 
         base_folder = Path(run_heat_exchanger.__file__).resolve().parent.parent
 

--- a/tests/test_warmingup_unit_cases.py
+++ b/tests/test_warmingup_unit_cases.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from unittest import TestCase
 
+import numpy as np
+from utils_tests import (demand_matching_test, energy_conservation_test,
+                         heat_to_discharge_test)
+
 from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.util import run_esdl_mesido_optimization
-
-import numpy as np
-
-from utils_tests import demand_matching_test, energy_conservation_test, heat_to_discharge_test
 
 
 class TestWarmingUpUnitCases(TestCase):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
 
+import numpy as np
+
 from mesido._darcy_weisbach import friction_factor, head_loss
 from mesido.constants import GRAVITATIONAL_CONSTANT
 from mesido.head_loss_class import HeadLossOption
-
-import numpy as np
 
 
 def feasibility_test(solution):


### PR DESCRIPTION
Summary
This pull request applies isort to automatically organize and format import statements across the codebase, ensuring adherence to PEP 8 guidelines.

Motivation
Ensures consistent import order and grouping according to PEP 8 and project standards
Improves code readability and maintainability
Resolves format warnings related to import order and grouping
Details
All Python files have been processed with isort
Imports are now grouped and ordered by type (standard library, third-party, local)
No functional changes—only import formatting
Impact
Cleaner, standardized imports throughout the project
Reduces merge conflicts related to import statements
Resolves flake8 and other format warnings about import order