### PR TITLE
Remove OUTPUT profiles at inport of assets before updating esdl

### DIFF
--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -937,7 +937,9 @@ class ScenarioOutput:
         ]:
             asset = self._name_to_asset(energy_system, asset_name)
             for iport in range(len(asset.port)):
-                if isinstance(asset.port[iport], esdl.OutPort) or isinstance(asset.port[iport], esdl.InPort):
+                if isinstance(asset.port[iport], esdl.OutPort) or isinstance(
+                    asset.port[iport], esdl.InPort
+                ):
                     profiles_to_remove = []
                     for iprofile in range(len(asset.port[iport].profile)):
                         if (


### PR DESCRIPTION
The simulator also writes output profiles to "inport" of some esdl assets. So we need to loop over these ports as well when removing OUTPUT profiles in the post processing (before updating the esdl) after an optimization.