### PR TITLE
Fixed opex cost attribute accepts yr time unit

### DIFF
--- a/src/mesido/esdl/asset_to_component_base.py
+++ b/src/mesido/esdl/asset_to_component_base.py
@@ -1470,8 +1470,10 @@ class _AssetToComponentBase:
                 continue
             if per_time != TimeUnitEnum.NONE:
                 message = (
-                    f"Specified OPEX for asset {asset.name} of type {asset.asset_type} includes a "
-                    f"component per time, but should be None."
+                    f"Specified variable OPEX for asset {asset.name} of type {asset.asset_type} "
+                    f"includes a component per time '{per_time}', but variable OPEX should be "
+                    f"specified as EUR/Wh (energy-based), with perTimeUnit set to 'NONE' instead "
+                    f"of '{per_time}'."
                 )
                 self._log_and_add_potential_issue(message, asset.id, cost_error_type="incorrect")
                 continue
@@ -1537,6 +1539,15 @@ class _AssetToComponentBase:
             if cost_value is not None and cost_value > 0.0:
                 if unit != UnitEnum.EURO:
                     message = f"Expected cost information {cost_info} to be provided in euros."
+                    self._log_and_add_potential_issue(
+                        message, asset.id, cost_error_type="incorrect"
+                    )
+                    continue
+                if per_time != TimeUnitEnum.NONE and per_time != TimeUnitEnum.YEAR:
+                    message = (
+                        f"Specified fixed OPEX for asset {asset.name} of type {asset.asset_type} "
+                        f"includes a component per time '{per_time}', but should be None or YEAR."
+                    )
                     self._log_and_add_potential_issue(
                         message, asset.id, cost_error_type="incorrect"
                     )


### PR DESCRIPTION
Fixed OPEX represents annual fixed operation and maintenance costs that scale with asset capacity (independent of operation), and in MESIDO's TCO calculation, the coefficient is multiplied by number_of_years (line 162 in minimize_tco_goal.py).

The current implementation implicitly treats EURO/MW as an annual rate (EURO/MW/yr).

#307 requests accepting both formats (implicit and explicit yearly units). This implementation now allows fixed OPEX to accept both perTimeUnit=NONE (implicit annual, backward compatible) and perTimeUnit=YEAR (explicit annual).

Variable OPEX correctly remains unchanged, as it's energy-based (EURO/Wh) and gets summed over timesteps rather than multiplied by years, making the /yr suffix physically incorrect for that cost type.

To be merged after #275