### PR TITLE
Fix pytest xdist hanging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,19 +21,19 @@ extras = all
 
 # Main tests part 1 (typical normal test)
 [testenv:test_env_main_1]
-commands = pytest -n auto -v --ignore=tests/test_updated_esdl_pre_process.py --ignore=tests/test_updated_esdl_post_process.py --ignore=tests/test_end_scenario_sizing.py -s
+commands = pytest -n 4 -v --ignore=tests/test_updated_esdl_pre_process.py --ignore=tests/test_updated_esdl_post_process.py --ignore=tests/test_end_scenario_sizing.py -s
 
 # Main tests part 2 (specifically for end scenario testing due to pipeline hanging problems)
 [testenv:test_env_main_2]
-commands = pytest -n auto -v tests/test_end_scenario_sizing.py -s
+commands = pytest -n 4 -v tests/test_end_scenario_sizing.py -s
 
 # Pre-processing / solve systems to create data for post-processing test environment
 [testenv:test_env_pre]
-commands = pytest -n auto -v tests/test_updated_esdl_pre_process.py -s
+commands = pytest -n 4 -v tests/test_updated_esdl_pre_process.py -s
 
 # Post process type of tests
 [testenv:test_env_post]
-commands = pytest -n auto -v tests/test_updated_esdl_post_process.py -s
+commands = pytest -n 4 -v tests/test_updated_esdl_post_process.py -s
 
 
 [testenv:flake8]


### PR DESCRIPTION
Tests were hanging intermittently, with timeouts occurring after 300+ seconds.

While exploring different hypotheses, I attempted several potential fixes:

- Downgraded pytest-xdist from 3.8.0 to 2.5.0 (July 2021) based on reported pytest-xdist issues:
[https://github.com/pytest-dev/pytest-xdist/issues/872]
[https://github.com/pytest-dev/pytest-xdist/issues/1237]
- Converted test structure in t`est_topo_constraints.py` from `unittest.TestCase` with `setUpClass` to pytest module-scoped fixtures

- Configured HiGHS solver thread safety by setting threads=1 and parallel="off" to prevent potential thread contention

In each of those cases the issue persisted.

For now, the only solution seems to be to limit the number of pytest-xdist workers to `-n 4` in the test environments. We should also test the effect of changes/updates on the dependencies.

Fixes #363 363