### PR TITLE
Fix for generic producer profiles from influx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [Unreleased-main] - 2025-11-19
+# [Unreleased-main] - 2025-11-24
 
 ## Added
 - xx
@@ -8,6 +8,19 @@
 
 ## Fixed
 - xx
+
+
+# [0.1.16] - 2025-11-24
+
+## Added
+- xx
+
+## Changed
+- xx
+
+## Fixed
+- Include GenericProducer in producer profile reading from influx
+
 
 # [0.1.15] - 2025-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@
 - xx
 
 ## Fixed
-- xx
-
-
-# [0.1.16] - 2025-11-24
-
-## Added
-- xx
-
-## Changed
-- xx
-
-## Fixed
 - Include GenericProducer in producer profile reading from influx
 
 

--- a/src/mesido/esdl/profile_parser.py
+++ b/src/mesido/esdl/profile_parser.py
@@ -210,6 +210,7 @@ class InfluxDBProfileReader(BaseProfileReader):
         esdl.esdl.HeatingDemand: ".target_heat_demand",
         esdl.esdl.GenericConsumer: ".target_heat_demand",
         esdl.esdl.HeatProducer: ".maximum_heat_source",
+        esdl.esdl.GenericProducer: ".maximum_heat_source",
         esdl.esdl.ElectricityDemand: ".target_electricity_demand",
         esdl.esdl.ElectricityProducer: ".maximum_electricity_source",
         esdl.esdl.GasDemand: ".target_gas_demand",


### PR DESCRIPTION
The approach will be updated such that the genericproducer can be used for any type of commodity.
The profile connected to it will be saved as with the suffix ".maximum_energy_source" and then depending on whether esdl.genericproducer in MESIDO becomes an electricity, gas or heat producer, the profile is renamed to  ".maximum_heat_source", ".maximum_electricity_source" etc.