### PR TITLE
bug ates variable operational cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - Bug: Write updated esdl for 2 port heat pump
 - Bug: 2 port heatpump write result profiles to database 
 - Bug: setting of self._pipe_heat_loss_nominals was not accounting for negative values when T_ground > carrier temperature
-- Bug: Variable Operational Cost for Ates is set as required in ASSET_COST_REQUIREMENTS dictionary
 
 
 # [0.1.15] - 2025-11-19

--- a/src/mesido/esdl/asset_to_component_base.py
+++ b/src/mesido/esdl/asset_to_component_base.py
@@ -284,7 +284,7 @@ class _AssetToComponentBase:
             "investmentCosts": "required",
             "installationCosts": "required",
             "fixedMaintenanceCosts": "optional",
-            "fixedOperationalCosts": "required",
+            "fixedOperationalCosts": "optional",
         },
         "gas_demand": {
             "variableOperationalCosts": "required",

--- a/tests/test_end_scenario_sizing.py
+++ b/tests/test_end_scenario_sizing.py
@@ -106,6 +106,7 @@ class TestEndScenarioSizing(TestCase):
             esdl_asset = self.solution.esdl_assets[self.solution.esdl_asset_name_to_id_map[f"{a}"]]
             costs_esdl_asset = esdl_asset.attributes["costInformation"]
             var_op_costs = costs_esdl_asset.variableOperationalCosts.value / 1.0e6  # EUR/Wh_th
+            self.assertNotEqual(0.0, var_op_costs)
             for ii in range(1, len(self.solution.times())):
                 variable_operational_cost += (
                     var_op_costs


### PR DESCRIPTION
Done:
- [x] ASSET_COST_REQUIREMENTS dictionary for ATES in asset_to_component_base is updated
- [x] Existing test_end_scenario_sizin is updated so that the calculation of variable operational cost of ates is verified.