### PR TITLE
DataSource to the output profiles (patch_dtk_2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # [Unreleased-main] - 2026-04-13
 
 ## Added
-- xxx
+- DataSource is assigned to output profiles
 
 ## Changed
-- xxx
+- Updated pyESDL to v26.3
 
 ## Fixed
 - xxx

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         # < 81.0.0 needed for pandapipes (still to be removed)
         # < 82.0.0 needed for pkg_resources (used in rtctools)
         "setuptools <= 80.9.0",
-        "pyesdl == 26.2",
+        "pyesdl == 26.3",
         "pandas >= 1.3.1, < 2.0",
         "casadi-gil-comp == 3.6.7",
         "StrEnum == 0.4.15",

--- a/src/mesido/workflows/io/write_output.py
+++ b/src/mesido/workflows/io/write_output.py
@@ -1461,6 +1461,14 @@ class ScenarioOutput:
                                             f"{asset_name}. + {variable}"
                                         )
 
+                                    # Write the source of profiles (Optimizer)
+                                    profile_attributes.dataSource = esdl.esdl.DataSource(
+                                        id=str(uuid.uuid4()),
+                                        name="Optimizer",
+                                        description="This was created in the optimizer",
+                                        type=esdl.DataSourceTypeEnum.MODEL,
+                                    )
+
                                 # Write result OUTPUT profiles on the optimized esdl
                                 asset.port[index_outport].profile.append(profile_attributes)
 


### PR DESCRIPTION
Use DataSource to indicate that output profiles are coming from the optimizer. Hence, source of output profiles will be clearly indicated in optimized esdl.
Todo:

- [x] modify write_output so that output profiles will have their sources assigned
- [x] update the version of pyesdl
- [x] update change log
- [x] check by connecting to InfluxDB at local if optimized esdl has datasource attributes at the output profiles 