### PR TITLE
Remove price profile requirement if electricity carrier available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added electricity cost profile to variable operational cost of assets which convert electricity to heat.
 - Heating_and_cooling example is cleaned up
 - The number of binary variables for the linearized head loss calculation is reduced by half, by only creating them for the positive quadrant.
+- No longer required to add an electricity price profile if an electricity carrier is available.
 
 ## Fixed
 - ProfileConstraints: Use already available function to get profile quantity and unit

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -792,8 +792,8 @@ class FinancialMixin(
     def __get_electricity_price_profile_or_zero(self):
         """
         Variable OPEX electricity costs currently support at most one electricity carrier.
-        Otherwise, there needs to be a link between  the electricity carrier and the
-        source and pump asset which is lots of extra effort for the user.
+        Otherwise, there needs to be a link between  the electricity carrier and the asset which
+        is lots of extra effort for the user.
         Returns the timeseries price profile for the electricity carrier or a zero array.
         """
         electricity_carriers = self.get_electricity_carriers()

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -789,6 +789,25 @@ class FinancialMixin(
     def __state_vector_scaled(self, variable, ensemble_member):
         return self._BaseProblemMixin__state_vector_scaled(variable, ensemble_member)
 
+    def __get_electricity_price_profile_or_zero(self):
+        """
+        Variable OPEX electricity costs currently support at most one electricity carrier.
+        Otherwise, there needs to be a link between  the electricity carrier and the
+        source and pump asset which is lots of extra effort for the user.
+        Returns the timeseries price profile for the electricity carrier or a zero array.
+        """
+        electricity_carriers = self.get_electricity_carriers()
+        assert len(electricity_carriers.keys()) <= 1
+
+        if len(electricity_carriers.keys()) == 0:
+            return Timeseries(self.times(), np.zeros(len(self.times())))
+
+        price_profile_name = f"{list(electricity_carriers.values())[0]['name']}.price_profile"
+        if price_profile_name in self.io.get_timeseries_names():
+            return self.get_timeseries(price_profile_name)
+
+        return Timeseries(self.times(), np.zeros(len(self.times())))
+
     def __investment_cost_constraints(self, ensemble_member):
         """
         This function adds constraints to set the investment cost variable. The investment cost
@@ -942,20 +961,7 @@ class FinancialMixin(
             pump_power = self.__state_vector_scaled(f"{asset}.Pump_power", ensemble_member)
             eff = parameters[f"{asset}.pump_efficiency"]
 
-            # We assume that only one electricity carrier is specified, to compute the cost with.
-            # Otherwise we need to link the electricity carrier somehow to the source and pump asset
-            # which is lots of extra effort for the user.
-            assert len(self.get_electricity_carriers().keys()) <= 1
-
-            if len(self.get_electricity_carriers().keys()) == 1:
-                try:
-                    price_profile = self.get_timeseries(
-                        f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                    )
-                except KeyError:
-                    price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
-            else:
-                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+            price_profile = self.__get_electricity_price_profile_or_zero()
 
             sum_ = ca.sum1(
                 variable_operational_cost_coefficient
@@ -979,17 +985,7 @@ class FinancialMixin(
             pump_power = self.__state_vector_scaled(f"{asset}.Pump_power", ensemble_member)
             eff = parameters[f"{asset}.pump_efficiency"]
 
-            # We assume that only one electricity carrier is specified, to compute the cost with.
-            # Otherwise we need to link the electricity carrier somehow to the source and pump asset
-            # which is lots of extra effort for the user.
-            assert len(self.get_electricity_carriers().keys()) <= 1
-
-            if len(self.get_electricity_carriers().keys()) == 1:
-                price_profile = self.get_timeseries(
-                    f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                )
-            else:
-                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+            price_profile = self.__get_electricity_price_profile_or_zero()
 
             sum_ = ca.sum1(price_profile.values[1:] * pump_power[1:] * timesteps_hr / eff)
 
@@ -1009,20 +1005,7 @@ class FinancialMixin(
             pump_power = self.__state_vector_scaled(f"{s}.Pump_power", ensemble_member)
             eff = parameters[f"{s}.pump_efficiency"]
 
-            # We assume that only one electricity carrier is specified, to compute the cost with.
-            # Otherwise we need to link the electricity carrier somehow to the source and pump asset
-            # which is lots of extra effort for the user.
-            assert len(self.get_electricity_carriers().keys()) <= 1
-
-            if len(self.get_electricity_carriers().keys()) == 1:
-                try:
-                    price_profile = self.get_timeseries(
-                        f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                    )
-                except KeyError:
-                    price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
-            else:
-                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+            price_profile = self.__get_electricity_price_profile_or_zero()
 
             nominator_vector = None
             denominator = 1.0
@@ -1090,17 +1073,7 @@ class FinancialMixin(
             pump_power = self.__state_vector_scaled(f"{hp}.Pump_power", ensemble_member)
             eff = parameters[f"{hp}.pump_efficiency"]
 
-            # We assume that only one electricity carrier is specified, to compute the cost with.
-            # Otherwise we need to link the electricity carrier somehow to the source and pump asset
-            # which is lots of extra effort for the user.
-            assert len(self.get_electricity_carriers().keys()) <= 1
-
-            if len(self.get_electricity_carriers().keys()) == 1:
-                price_profile = self.get_timeseries(
-                    f"{list(self.get_electricity_carriers().values())[0]['name']}.price_profile"
-                )
-            else:
-                price_profile = Timeseries(self.times(), np.zeros(len(self.times())))
+            price_profile = self.__get_electricity_price_profile_or_zero()
 
             sum_ = ca.sum1(
                 variable_operational_cost_coefficient * elec_consumption[1:] * timesteps_hr


### PR DESCRIPTION
Fixed that no longer a price profile is needed is an electricity carrier is available