### PR TITLE
Use heatsource based on varying supply temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [Unreleased-main] - 2026-05-13
+# [Unreleased-main] - 2026-05-29
 
 ## Added
 - Electricity consumption calculation of geothermal assets, using the defined COP. 
@@ -12,6 +12,7 @@
 - Ramp constraints for heat producers are added.
 - Maximum and minimum temperature of heat sources are parsed from esdl
 - Warnings on potential causes of heat demand not being matched are added in the grow workflow
+- A heat source asset is eligible for use only when its maximum temperature meets or exceeds the varying network supply temperatures
 
 ## Changed
 - Reduced the number of constraints required for headloss calculation with LINEARIZED_N_LINES_EQUALITY setting.

--- a/src/mesido/heat_physics_mixin.py
+++ b/src/mesido/heat_physics_mixin.py
@@ -1439,9 +1439,15 @@ class HeatPhysicsMixin(
                             f"{sup_carrier}_{supply_temperature}"
                         )
 
+                        heat_out_expected = discharge * cp * rho * supply_temperature
+                        if (0.0 < parameters[f"{s}.max_temperature"]) and (
+                            parameters[f"{s}.max_temperature"] < supply_temperature
+                        ):
+                            heat_out_expected = 0.0
+
                         constraints.extend(
                             self._symmetric_big_m_constraints(
-                                heat_out - discharge * cp * rho * supply_temperature,
+                                heat_out - heat_out_expected,
                                 (1.0 - sup_temperature_is_selected) * big_m,
                                 constraint_nominal,
                             )

--- a/tests/models/unit_cases/case_1a/model/1a_with_2producers_and_supply_temperature_options.esdl
+++ b/tests/models/unit_cases/case_1a/model/1a_with_2producers_and_supply_temperature_options.esdl
@@ -150,6 +150,7 @@
       <carrier xsi:type="esdl:HeatCommodity" id="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" name="Heat_ret" returnTemperature="45.0"/>
       <carrier xsi:type="esdl:HeatCommodity" id="c362f53a-3eaf-4d96-8ee6-944e77359fed" name="Heat" supplyTemperature="75.0"/>
       <carrier xsi:type="esdl:HeatCommodity" id="00585af4-89aa-46da-a76e-2793bf3622e4" name="Heat_71" supplyTemperature="71.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" id="9f6aeb1a-138b-4bb9-9a09-d524e94658e6" name="Heat_74" supplyTemperature="74.0"/>
       <carrier xsi:type="esdl:HeatCommodity" id="95500b26-7b90-4057-9183-e99bd056bd2c" name="Heat_86" supplyTemperature="86.0"/>
     </carriers>
   </energySystemInformation>

--- a/tests/models/unit_cases/case_1a/model/1a_with_2producers_and_supply_temperature_options.esdl
+++ b/tests/models/unit_cases/case_1a/model/1a_with_2producers_and_supply_temperature_options.esdl
@@ -1,0 +1,156 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<esdl:EnergySystem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:esdl="http://www.tno.nl/esdl" id="b9f8b83d-49e2-4c8b-9992-240ed4643329" name="1a_with_2producers_and_supply_temperature_options" description="" esdlVersion="v2211" version="6">
+  <instance xsi:type="esdl:Instance" id="22cf0465-ceef-486a-b8d0-278c131cbece" name="Untitled Instance">
+    <area xsi:type="esdl:Area" id="a5845d28-ed01-4f32-91dc-654632ecc997" name="Untitled Area">
+      <asset xsi:type="esdl:HeatingDemand" id="2ab92324-f86e-4976-9a6e-f7454b77ba3c" minTemperature="70.0" power="1000000.0" name="HeatingDemand_2ab9">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="51.98612564800895" lon="4.38157081604004"/>
+        <port xsi:type="esdl:InPort" name="In" id="3f514c6b-fd11-4821-9e6c-4a4d13d46762" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed" connectedTo="95f46ccf-bac8-4a44-a854-2bbe2fb3c5e6">
+          <profile xsi:type="esdl:SingleValue" value="0.1" id="5317d120-2e6e-415d-a3bc-bdd6268997d3">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
+          </profile>
+        </port>
+        <port xsi:type="esdl:OutPort" name="Out" id="d86d3ed7-77d8-4766-bfa1-ed9209edf0b6" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" connectedTo="75a9a056-987d-41dc-9ecf-ca3edfef31d8"/>
+      </asset>
+      <asset xsi:type="esdl:HeatingDemand" id="6662aebb-f85e-4df3-9f7e-c58993586fba" minTemperature="70.0" power="1000000.0" name="HeatingDemand_6662">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="51.985484727746204" lon="4.381640553474427"/>
+        <port xsi:type="esdl:InPort" name="In" id="5f607bc1-31a6-4bc8-8911-aefd4d2cfc4d" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed" connectedTo="99e5f517-4fbb-4e1e-89e2-606f1121adeb">
+          <profile xsi:type="esdl:SingleValue" value="0.1" id="5317d120-2e6e-415d-a3bc-bdd6268997d3">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
+          </profile>
+        </port>
+        <port xsi:type="esdl:OutPort" name="Out" id="560eb546-6e19-4fb7-9dce-741ed12310a6" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" connectedTo="27daf107-0ce8-4870-bb8c-45421a62ed83"/>
+      </asset>
+      <asset xsi:type="esdl:ResidualHeatSource" id="8172d5d3-61a4-4d0b-a26f-5e61c2a22c64" minTemperature="65.0" maxTemperature="85.0" power="2000000.0" name="ResidualHeat_expensive">
+        <geometry xsi:type="esdl:Point" lat="51.985595402776624" lon="4.379819333553315"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="974230fb-e753-4fc1-a762-82de7d960e62" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed" connectedTo="adb264b4-2ba0-4a49-9fc7-f57a29fb6346"/>
+        <port xsi:type="esdl:InPort" name="In" id="4b5d5d6c-82ef-441b-9e0b-478cf3c8031c" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" connectedTo="ba6017c5-bedf-411c-9e49-72f0b5053991"/>
+        <costInformation xsi:type="esdl:CostInformation" id="922dcf25-d360-4078-a4f6-5d8ef49616a7">
+          <variableOperationalCosts xsi:type="esdl:SingleValue" id="57c019c2-148b-4ab8-9e6e-4f1774fc039d" value="100.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" physicalQuantity="COST" description="Cost in EUR/MWh" id="828d850b-280d-469c-adfb-36268ef1c99c" unit="EURO" perMultiplier="MEGA" perUnit="WATTHOUR"/>
+          </variableOperationalCosts>
+        </costInformation>
+      </asset>
+      <asset xsi:type="esdl:Joint" id="ed9a2b96-2fff-4650-b875-41c6f05a6e44" name="Joint_9580_ret">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="51.985749025873034" lon="4.3802350759506234"/>
+        <port xsi:type="esdl:InPort" name="In" id="adb264b4-2ba0-4a49-9fc7-f57a29fb6346" connectedTo="974230fb-e753-4fc1-a762-82de7d960e62 efaeb481-99cf-4071-b1f1-9041f1a56922" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="061f1df2-f724-4b08-aa5f-6f19b06c2f92" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed" connectedTo="a779e3ec-8215-43c9-84ff-baa1c93abfea df318cbd-81f2-467c-a081-7feb4256dbfa 14757d8c-9685-47e2-bf2a-517ee556ab56"/>
+      </asset>
+      <asset xsi:type="esdl:Joint" id="95802cf8-61d6-4773-bb99-e275c3bf26cc" name="Joint_9580">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="51.98563669935972" lon="4.380224347114564"/>
+        <port xsi:type="esdl:InPort" name="In" id="e3bbc000-98be-43d7-898e-7a503871786f" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" connectedTo="388ae7b7-2a05-4b50-acf7-adebf4c24ab4 1f153f2f-adf6-4e3b-94ca-aef1644e8c7d c7ef3ba2-332e-4c8d-bc53-449179a4bc22"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="ba6017c5-bedf-411c-9e49-72f0b5053991" connectedTo="4b5d5d6c-82ef-441b-9e0b-478cf3c8031c d6bf4a19-117e-4a03-b6e4-1acca1a63f2b" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+      </asset>
+      <asset xsi:type="esdl:Pipe" id="275a0b40-b6ce-4e7d-b954-efeff0f25734" length="72.13358767664306" innerDiameter="0.16030000000000003" outerDiameter="0.25" name="Pipe_275a">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="51.98579197417133" lon="4.380412101745606"/>
+          <point xsi:type="esdl:Point" lat="51.98609261110622" lon="4.381345510482789"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" name="In" id="a779e3ec-8215-43c9-84ff-baa1c93abfea" connectedTo="061f1df2-f724-4b08-aa5f-6f19b06c2f92" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="95f46ccf-bac8-4a44-a854-2bbe2fb3c5e6" connectedTo="3f514c6b-fd11-4821-9e6c-4a4d13d46762" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.004">
+            <matter xsi:type="esdl:Material" id="c4af6ec7-a8da-4412-b4c4-62d3b5c8ecb8" name="steel" thermalConductivity="0.00014862917548188605"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.03725">
+            <matter xsi:type="esdl:Material" id="b74a8c0f-9c8a-4a02-8055-c77943b414c1" name="PUR" thermalConductivity="2.1603217928675567"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0036000000000000003">
+            <matter xsi:type="esdl:Material" id="aff626e3-66f1-470f-a86d-f1f6adb336cb" name="HDPE" thermalConductivity="0.011627406024262562"/>
+          </component>
+        </material>
+      </asset>
+      <asset xsi:type="esdl:Pipe" id="b5babf87-0530-49b5-914d-008d733ac5bf" length="73.56064145043287" innerDiameter="0.16030000000000003" outerDiameter="0.25" name="Pipe_b5ba">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="51.98563339563447" lon="4.380374550819398"/>
+          <point xsi:type="esdl:Point" lat="51.98549794268959" lon="4.381425976753236"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" name="In" id="14757d8c-9685-47e2-bf2a-517ee556ab56" connectedTo="061f1df2-f724-4b08-aa5f-6f19b06c2f92" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="99e5f517-4fbb-4e1e-89e2-606f1121adeb" connectedTo="5f607bc1-31a6-4bc8-8911-aefd4d2cfc4d" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.004">
+            <matter xsi:type="esdl:Material" id="c4af6ec7-a8da-4412-b4c4-62d3b5c8ecb8" name="steel" thermalConductivity="0.00014862917548188605"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.03725">
+            <matter xsi:type="esdl:Material" id="b74a8c0f-9c8a-4a02-8055-c77943b414c1" name="PUR" thermalConductivity="2.1603217928675567"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0036000000000000003">
+            <matter xsi:type="esdl:Material" id="aff626e3-66f1-470f-a86d-f1f6adb336cb" name="HDPE" thermalConductivity="0.011627406024262562"/>
+          </component>
+        </material>
+      </asset>
+      <asset xsi:type="esdl:Pipe" id="5871f6ef-5d92-4a13-8843-6c56c2ac747f" length="70.32745329931934" innerDiameter="0.16030000000000003" outerDiameter="0.25" name="Pipe_5871">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="51.98571598869247" lon="4.380438923835755"/>
+          <point xsi:type="esdl:Point" lat="51.985758937022446" lon="4.381463527679444"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" name="In" id="df318cbd-81f2-467c-a081-7feb4256dbfa" connectedTo="061f1df2-f724-4b08-aa5f-6f19b06c2f92" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="c9d98764-3e85-4676-9504-73f7eeb242f5" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed" connectedTo="ee56b88f-a264-4389-ba57-6f2b52a05e1c"/>
+        <material xsi:type="esdl:CompoundMatter" compoundType="LAYERED">
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.004">
+            <matter xsi:type="esdl:Material" id="c4af6ec7-a8da-4412-b4c4-62d3b5c8ecb8" name="steel" thermalConductivity="0.00014862917548188605"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.03725">
+            <matter xsi:type="esdl:Material" id="b74a8c0f-9c8a-4a02-8055-c77943b414c1" name="PUR" thermalConductivity="2.1603217928675567"/>
+          </component>
+          <component xsi:type="esdl:CompoundMatterComponent" layerWidth="0.0036000000000000003">
+            <matter xsi:type="esdl:Material" id="aff626e3-66f1-470f-a86d-f1f6adb336cb" name="HDPE" thermalConductivity="0.011627406024262562"/>
+          </component>
+        </material>
+      </asset>
+      <asset xsi:type="esdl:HeatingDemand" id="506c41ac-d415-4482-bf10-bf12f17aeac6" minTemperature="70.0" power="1000000.0" name="HeatingDemand_506c">
+        <geometry xsi:type="esdl:Point" CRS="WGS84" lat="51.98578206302921" lon="4.381629824638368"/>
+        <port xsi:type="esdl:InPort" name="In" id="ee56b88f-a264-4389-ba57-6f2b52a05e1c" connectedTo="c9d98764-3e85-4676-9504-73f7eeb242f5" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed">
+          <profile xsi:type="esdl:SingleValue" value="0.1" id="5317d120-2e6e-415d-a3bc-bdd6268997d3">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitReference" reference="e9405fc8-5e57-4df5-8584-4babee7cdf1b"/>
+          </profile>
+        </port>
+        <port xsi:type="esdl:OutPort" name="Out" id="a4d4447f-683c-4daf-aafd-f20efc13bd43" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" connectedTo="e3839971-e5b0-4b3a-9c55-ac2baab8966a"/>
+      </asset>
+      <asset xsi:type="esdl:Pipe" id="22771285-490c-42e3-a6be-82c383b5f21e" length="72.13358767664306" innerDiameter="0.16030000000000003" outerDiameter="0.25" name="Pipe_275a_ret">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="51.98607261110622" lon="4.381325510482789"/>
+          <point xsi:type="esdl:Point" lat="51.98577197417133" lon="4.380392101745606"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" name="In" id="75a9a056-987d-41dc-9ecf-ca3edfef31d8" connectedTo="d86d3ed7-77d8-4766-bfa1-ed9209edf0b6" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="c7ef3ba2-332e-4c8d-bc53-449179a4bc22" connectedTo="e3bbc000-98be-43d7-898e-7a503871786f" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+      </asset>
+      <asset xsi:type="esdl:Pipe" id="e68bff9f-422c-4a1b-90b0-80a5bfc1cabf" length="70.32745329931934" innerDiameter="0.16030000000000003" outerDiameter="0.25" name="Pipe_5871_ret">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="51.98573893702245" lon="4.381443527679444"/>
+          <point xsi:type="esdl:Point" lat="51.98569598869247" lon="4.380418923835755"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" name="In" id="e3839971-e5b0-4b3a-9c55-ac2baab8966a" connectedTo="a4d4447f-683c-4daf-aafd-f20efc13bd43" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="1f153f2f-adf6-4e3b-94ca-aef1644e8c7d" connectedTo="e3bbc000-98be-43d7-898e-7a503871786f" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+      </asset>
+      <asset xsi:type="esdl:Pipe" id="4605c1d2-62fc-40f3-8451-c6335b8d822a" length="73.56064145043287" innerDiameter="0.16030000000000003" outerDiameter="0.25" name="Pipe_b5ba_ret">
+        <geometry xsi:type="esdl:Line" CRS="WGS84">
+          <point xsi:type="esdl:Point" lat="51.98547794268959" lon="4.381405976753236"/>
+          <point xsi:type="esdl:Point" lat="51.98561339563447" lon="4.380354550819398"/>
+        </geometry>
+        <port xsi:type="esdl:InPort" name="In" id="27daf107-0ce8-4870-bb8c-45421a62ed83" connectedTo="560eb546-6e19-4fb7-9dce-741ed12310a6" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="388ae7b7-2a05-4b50-acf7-adebf4c24ab4" connectedTo="e3bbc000-98be-43d7-898e-7a503871786f" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+      </asset>
+      <asset xsi:type="esdl:ResidualHeatSource" id="de0b4c1f-70f3-4d0d-8e63-09fa5fc71d0d" minTemperature="65.0" maxTemperature="70.0" power="2000000.0" name="ResidualHeat_cheap">
+        <geometry xsi:type="esdl:Point" lat="51.98569864416294" lon="4.379828721284867"/>
+        <port xsi:type="esdl:OutPort" name="Out" id="efaeb481-99cf-4071-b1f1-9041f1a56922" connectedTo="adb264b4-2ba0-4a49-9fc7-f57a29fb6346" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed"/>
+        <port xsi:type="esdl:InPort" name="In" id="d6bf4a19-117e-4a03-b6e4-1acca1a63f2b" connectedTo="ba6017c5-bedf-411c-9e49-72f0b5053991" carrier="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret"/>
+        <costInformation xsi:type="esdl:CostInformation" id="4b31fd55-a586-4818-b18d-202e876f7ad1">
+          <variableOperationalCosts xsi:type="esdl:SingleValue" id="57c019c2-148b-4ab8-9e6e-4f1774fc039d" value="10.0">
+            <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" physicalQuantity="COST" description="Cost in EUR/MWh" id="828d850b-280d-469c-adfb-36268ef1c99c" unit="EURO" perMultiplier="MEGA" perUnit="WATTHOUR"/>
+          </variableOperationalCosts>
+        </costInformation>
+      </asset>
+    </area>
+  </instance>
+  <energySystemInformation xsi:type="esdl:EnergySystemInformation" id="eebe64dd-045f-49d5-9177-1e9a96a030f3">
+    <quantityAndUnits xsi:type="esdl:QuantityAndUnits" id="c7104449-b5eb-49c7-b064-a2a4b16ae6e4">
+      <quantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="e9405fc8-5e57-4df5-8584-4babee7cdf1b" description="Power in MW" physicalQuantity="POWER" unit="WATT" multiplier="MEGA"/>
+    </quantityAndUnits>
+    <carriers xsi:type="esdl:Carriers" id="823f0f5a-89a9-498e-a6b7-482a08ad95b2">
+      <carrier xsi:type="esdl:HeatCommodity" id="c362f53a-3eaf-4d96-8ee6-944e77359fed_ret" name="Heat_ret" returnTemperature="45.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" id="c362f53a-3eaf-4d96-8ee6-944e77359fed" name="Heat" supplyTemperature="75.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" id="00585af4-89aa-46da-a76e-2793bf3622e4" name="Heat_71" supplyTemperature="71.0"/>
+      <carrier xsi:type="esdl:HeatCommodity" id="95500b26-7b90-4057-9183-e99bd056bd2c" name="Heat_86" supplyTemperature="86.0"/>
+    </carriers>
+  </energySystemInformation>
+</esdl:EnergySystem>

--- a/tests/models/unit_cases/case_1a/src/run_1a.py
+++ b/tests/models/unit_cases/case_1a/src/run_1a.py
@@ -106,20 +106,26 @@ class HeatProblemTvarWithTechnoEconomicMixin(HeatProblemTvar, TechnoEconomicMixi
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.base_carrier_name = "Heat"
-        self.base_id_number_mapping = self._get_id_number_mapping_from_carrier_name(
-            self.base_carrier_name
-        )
+        self.base_carrier_id = self._get_id_from_carrier_name(self.base_carrier_name)
 
     def temperature_regimes(self, carrier):
         temperatures = []
-        if carrier == self.base_id_number_mapping:
+        if carrier == self.base_carrier_id:
             temperatures = self._get_related_carrier_temperatures(self.base_carrier_name)
         return temperatures
 
-    def _get_id_number_mapping_from_carrier_name(self, carrier_name: str):
+    def _get_id_from_carrier_name(self, carrier_name: str):
+        """
+        Return the id of the carrier with the given name.
+
+        Parameters
+        ----------
+        carrier_name : Name of the carrier for which the id is requested.
+        """
+
         return next(
             (
-                carrier.get("id_number_mapping")
+                carrier.get("id")
                 for carrier in self.esdl_carriers.values()
                 if carrier.get("name") == carrier_name
             ),
@@ -127,6 +133,17 @@ class HeatProblemTvarWithTechnoEconomicMixin(HeatProblemTvar, TechnoEconomicMixi
         )
 
     def _get_related_carrier_temperatures(self, carrier_name: str):
+        """
+        Return the sorted temperatures of carriers related to the given carrier name.
+
+        A carrier is considered related if its name starts with ``<carrier_name>_``
+        followed by a numeric suffix, for example ``Heat_70`` or ``Heat_90``.
+
+        Parameters
+        ----------
+        carrier_name : Base name of the carrier group.
+        """
+
         return sorted(
             carrier["temperature"]
             for carrier in self.esdl_carriers.values()

--- a/tests/models/unit_cases/case_1a/src/run_1a.py
+++ b/tests/models/unit_cases/case_1a/src/run_1a.py
@@ -3,6 +3,7 @@ from mesido.esdl.esdl_parser import ESDLFileParser
 from mesido.esdl.profile_parser import ProfileReaderFromFile
 from mesido.physics_mixin import PhysicsMixin
 from mesido.qth_not_maintained.qth_mixin import QTHMixin
+from mesido.techno_economic_mixin import TechnoEconomicMixin
 
 import numpy as np
 
@@ -111,6 +112,16 @@ class HeatProblemTvar(HeatProblem):
                         )
 
         return constraints
+
+
+class HeatProblemTvarWithTechnoEconomicMixin(HeatProblemTvar, TechnoEconomicMixin):
+    def temperature_regimes(self, carrier):
+        temperatures = []
+        if carrier == 3625334968694477359:
+            # supply
+            temperatures = [71.0, 74.0, 86.0]
+
+        return temperatures
 
 
 class QTHProblem(

--- a/tests/models/unit_cases/case_1a/src/run_1a.py
+++ b/tests/models/unit_cases/case_1a/src/run_1a.py
@@ -115,13 +115,38 @@ class HeatProblemTvar(HeatProblem):
 
 
 class HeatProblemTvarWithTechnoEconomicMixin(HeatProblemTvar, TechnoEconomicMixin):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.base_carrier_name = "Heat"
+        self.base_id_number_mapping = self._get_id_number_mapping_from_carrier_name(
+            self.base_carrier_name
+        )
+
     def temperature_regimes(self, carrier):
         temperatures = []
-        if carrier == 3625334968694477359:
-            # supply
-            temperatures = [71.0, 74.0, 86.0]
-
+        if carrier == self.base_id_number_mapping:
+            temperatures = self._get_related_carrier_temperatures(self.base_carrier_name)
         return temperatures
+
+    def _get_id_number_mapping_from_carrier_name(self, carrier_name: str):
+        return next(
+            (
+                carrier.get("id_number_mapping")
+                for carrier in self.esdl_carriers.values()
+                if carrier.get("name") == carrier_name
+            ),
+            None,
+        )
+
+    def _get_related_carrier_temperatures(self, carrier_name: str):
+        return sorted(
+            carrier["temperature"]
+            for carrier in self.esdl_carriers.values()
+            if carrier_name
+            and carrier.get("name", "").startswith(f"{carrier_name}_")
+            and carrier["name"][len(f"{carrier_name}_") :].isdigit()
+        )
 
 
 class QTHProblem(

--- a/tests/test_varying_temperature.py
+++ b/tests/test_varying_temperature.py
@@ -15,14 +15,13 @@ class TestVaryingTemperature(TestCase):
     def test_1a_heatsource_usage_based_on_varying_supply_temperature(self):
         """
         This test is to check whether the optimizer selects the expected heat source
-        based on the supply temperature. We set up a simple network with two residual
+        based on the network supply temperature. We set up a simple network with two residual
         heat sources, one cheap and one expensive, where the cheap one has a maximum
-        supply temperature that is below the demand temperature, and the expensive
-        one has a maximum supply temperature that is above the demand temperature.
+        temperature that is below the network supply temperature, and the expensive
+        one has a maximum temperature that is above the network supply temperature.
         In addition, the network has multiple supply temperature options, and we
         expect the optimizer to select the lowest feasible supply temperature.
-        We expect the optimizer to select the expensive heat source to meet
-        the demand, and thus not use the cheap heat source at all.
+        We expect the optimizer to use only the expensive heat source.
 
         Checks:
         - Variable operational cost coefficients of heat producers
@@ -60,9 +59,11 @@ class TestVaryingTemperature(TestCase):
 
         # Check that from the options the lowest supply temperature is selected
         # for the network supply temperature
+        carrier_id_number = "3625334968694477359"
+        temperature_regimes = heat_problem.temperature_regimes(int(carrier_id_number))
         np.testing.assert_equal(
-            71.0,
-            results["3625334968694477359_temperature"],
+            min(temperature_regimes),
+            results[f"{carrier_id_number}_temperature"],
         )
 
         # Check that the maximum supply temperature of the cheap heat source
@@ -73,7 +74,7 @@ class TestVaryingTemperature(TestCase):
         )
         np.testing.assert_array_less(
             parameters[f"{rh_cheap_id}.max_temperature"],
-            results["3625334968694477359_temperature"],
+            results[f"{carrier_id_number}_temperature"],
         )
 
         # Check that the maximum supply temperature of the expensive heat source
@@ -83,7 +84,7 @@ class TestVaryingTemperature(TestCase):
             parameters[f"{rh_expensive_id}.max_temperature"],
         )
         np.testing.assert_array_less(
-            results["3625334968694477359_temperature"],
+            results[f"{carrier_id_number}_temperature"],
             parameters[f"{rh_expensive_id}.max_temperature"],
         )
 

--- a/tests/test_varying_temperature.py
+++ b/tests/test_varying_temperature.py
@@ -19,9 +19,10 @@ class TestVaryingTemperature(TestCase):
         heat sources, one cheap and one expensive, where the cheap one has a maximum
         temperature that is below the network supply temperature, and the expensive
         one has a maximum temperature that is above the network supply temperature.
+        We expect the optimizer to use only the expensive heat source.
+
         In addition, the network has multiple supply temperature options, and we
         expect the optimizer to select the lowest feasible supply temperature.
-        We expect the optimizer to use only the expensive heat source.
 
         Checks:
         - Variable operational cost coefficients of heat producers
@@ -59,7 +60,7 @@ class TestVaryingTemperature(TestCase):
 
         # Check that from the options the lowest supply temperature is selected
         # for the network supply temperature
-        carrier_id_number = "3625334968694477359"
+        carrier_id_number = heat_problem._get_id_number_mapping_from_carrier_name("Heat")
         temperature_regimes = heat_problem.temperature_regimes(int(carrier_id_number))
         np.testing.assert_equal(
             min(temperature_regimes),

--- a/tests/test_varying_temperature.py
+++ b/tests/test_varying_temperature.py
@@ -12,6 +12,85 @@ from utils_tests import demand_matching_test, energy_conservation_test, heat_to_
 
 
 class TestVaryingTemperature(TestCase):
+    def test_1a_heatsource_usage_based_on_varying_supply_temperature(self):
+        """
+        This test is to check whether the optimizer selects the expected heat source
+        based on the supply temperature. We set up a simple network with two residual
+        heat sources, one cheap and one expensive, where the cheap one has a maximum
+        supply temperature that is below the demand temperature, and the expensive
+        one has a maximum supply temperature that is above the demand temperature.
+        In addition, the network has multiple supply temperature options, and we
+        expect the optimizer to select the lowest feasible supply temperature.
+        We expect the optimizer to select the expensive heat source to meet
+        the demand, and thus not use the cheap heat source at all.
+
+        Checks:
+        - Variable operational cost coefficients of heat producers
+        - Selection of the lowest feasible supply temperature from available options
+        - Maximum supply temperature of heat producers
+        - Check that the expensive heat source is used instead of the cheap heat source
+        """
+
+        import models.unit_cases.case_1a.src.run_1a as run_1a
+        from models.unit_cases.case_1a.src.run_1a import HeatProblemTvarWithTechnoEconomicMixin
+
+        base_folder = Path(run_1a.__file__).resolve().parent.parent
+
+        heat_problem = run_esdl_mesido_optimization(
+            HeatProblemTvarWithTechnoEconomicMixin,
+            base_folder=base_folder,
+            esdl_file_name="1a_with_2producers_and_supply_temperature_options.esdl",
+            esdl_parser=ESDLFileParser,
+            profile_reader=ProfileReaderFromFile,
+            input_timeseries_file="timeseries_import.xml",
+        )
+
+        results = heat_problem.extract_results()
+        parameters = heat_problem.parameters(0)
+        name_to_id_map = heat_problem.esdl_asset_name_to_id_map
+
+        rh_cheap_id = name_to_id_map["ResidualHeat_cheap"]
+        rh_expensive_id = name_to_id_map["ResidualHeat_expensive"]
+
+        # Check variable operational cost coefficients
+        np.testing.assert_array_less(
+            parameters[f"{rh_cheap_id}.variable_operational_cost_coefficient"],
+            parameters[f"{rh_expensive_id}.variable_operational_cost_coefficient"],
+        )
+
+        # Check that from the options the lowest supply temperature is selected
+        # for the network supply temperature
+        np.testing.assert_equal(
+            71.0,
+            results["3625334968694477359_temperature"],
+        )
+
+        # Check that the maximum supply temperature of the cheap heat source
+        # is below the supply temperature
+        np.testing.assert_equal(
+            heat_problem.esdl_assets[f"{rh_cheap_id}"].attributes["maxTemperature"],
+            parameters[f"{rh_cheap_id}.max_temperature"],
+        )
+        np.testing.assert_array_less(
+            parameters[f"{rh_cheap_id}.max_temperature"],
+            results["3625334968694477359_temperature"],
+        )
+
+        # Check that the maximum supply temperature of the expensive heat source
+        # is above the supply temperature
+        np.testing.assert_equal(
+            heat_problem.esdl_assets[f"{rh_expensive_id}"].attributes["maxTemperature"],
+            parameters[f"{rh_expensive_id}.max_temperature"],
+        )
+        np.testing.assert_array_less(
+            results["3625334968694477359_temperature"],
+            parameters[f"{rh_expensive_id}.max_temperature"],
+        )
+
+        # Check expensive heat source is used instead of cheap heat source
+        np.testing.assert_array_less(1e3, results[f"{rh_expensive_id}.Heat_source"])
+        np.testing.assert_allclose(0.0, results[f"{rh_cheap_id}.Heat_source"])
+
     def test_1a_temperature_variation(self):
         """
         This test is to check if the varying network temperature works as expected on a simple
@@ -465,6 +544,7 @@ if __name__ == "__main__":
 
     start_time = time.time()
     a = TestVaryingTemperature()
+    a.test_1a_heatsource_usage_based_on_varying_supply_temperature()
     a.test_1a_temperature_variation()
     a.test_3a_temperature_variation_supply()
     a.test_3a_temperature_variation_return()

--- a/tests/test_varying_temperature.py
+++ b/tests/test_varying_temperature.py
@@ -60,8 +60,8 @@ class TestVaryingTemperature(TestCase):
 
         # Check that from the options the lowest supply temperature is selected
         # for the network supply temperature
-        carrier_id_number = heat_problem._get_id_number_mapping_from_carrier_name("Heat")
-        temperature_regimes = heat_problem.temperature_regimes(int(carrier_id_number))
+        carrier_id_number = heat_problem._get_id_from_carrier_name("Heat")
+        temperature_regimes = heat_problem.temperature_regimes(carrier_id_number)
         np.testing.assert_equal(
             min(temperature_regimes),
             results[f"{carrier_id_number}_temperature"],


### PR DESCRIPTION
Use heatsource if asset max temperature is larger than or equal to network supply temperature for the case with network supply temperature has multiple temperature options:

- [x] Modify heat_physics_mixing so that heat_out of heat_source will be zero if network supply temperature is greater than the max temperature of the asset. Apply this to all the supply temperature options
- [x] Create a new test. Place 2 heat source and set the cheap heat source maximum temperature lower than the network supply temperature. Define multiple temperature options to the supply temperature. Show that optimizer uses only expensive heat source and smallest supply temperature is selected.