### PR TITLE
476 profile timeseries extracted with incorrect dimensions when indexing is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ## Fixed
 - ProfileConstraints: Use already available function to get profile quantity and unit
+- Electricity carriers no longer require a price profile.
 
 
 # [0.1.18.1] - 2026-04-13

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -1816,9 +1816,10 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
         if f"{asset.id}.{variable_suffix}" in self.io.get_timeseries_names():
             timeseries = self.get_timeseries(f"{asset.id}.{variable_suffix}")
             if len(self.times()) < len(timeseries.times):
-                idx_start = np.where(timeseries.times == self.times()[0])[0][0]
-                idx_end = np.where(timeseries.times == self.times()[-1])[0][0]
-                profile_non_scaled = timeseries.values[idx_start : idx_end + 1]
+                mask = (timeseries.times >= self.times()[0]) & (
+                    timeseries.times <= self.times()[-1]
+                )
+                profile_non_scaled = timeseries.values[mask]
             else:
                 profile_non_scaled = timeseries.values
             max_profile_non_scaled = max(profile_non_scaled)

--- a/src/mesido/electricity_physics_mixin.py
+++ b/src/mesido/electricity_physics_mixin.py
@@ -264,7 +264,8 @@ class ElectricityPhysicsMixin(
                 ub = self.get_timeseries(f"{asset}.maximum_electricity_source")
                 start_indx = np.where(ub.times == t[0])[0][0]
                 end_indx = np.where(ub.times == t[-1])[0][0] + 1
-                ub = Timeseries(t, (np.asarray(ub.values)[start_indx:end_indx]).tolist())
+                mask = (ub.times >= t[0]) & (ub.times <= t[-1])
+                ub = Timeseries(t, (np.asarray(ub.values)[mask]).tolist())
                 self.__electricity_producer_upper_bounds[f"{asset}.Electricity_source"] = (lb, ub)
 
     def __electricity_producer_set_point_constraints(self, ensemble_member):

--- a/src/mesido/electricity_physics_mixin.py
+++ b/src/mesido/electricity_physics_mixin.py
@@ -262,8 +262,6 @@ class ElectricityPhysicsMixin(
             if f"{asset}.maximum_electricity_source" in timeseries_io_names:
                 lb = Timeseries(t, np.zeros(len(t)))
                 ub = self.get_timeseries(f"{asset}.maximum_electricity_source")
-                start_indx = np.where(ub.times == t[0])[0][0]
-                end_indx = np.where(ub.times == t[-1])[0][0] + 1
                 mask = (ub.times >= t[0]) & (ub.times <= t[-1])
                 ub = Timeseries(t, (np.asarray(ub.values)[mask]).tolist())
                 self.__electricity_producer_upper_bounds[f"{asset}.Electricity_source"] = (lb, ub)

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -810,7 +810,7 @@ class FinancialMixin(
             price_profile = price_profile_timeseries.values[mask]
             return price_profile
 
-        return Timeseries(self.times(), np.zeros(len(self.times())))
+        return np.zeros(len(self.times()))
 
     def __investment_cost_constraints(self, ensemble_member):
         """
@@ -972,7 +972,7 @@ class FinancialMixin(
                 * (heat_charge[1:] + heat_discharge[1:])
                 * timesteps
             )
-            sum_ += ca.sum1(price_profile.values[1:] * pump_power[1:] * timesteps / eff)
+            sum_ += ca.sum1(price_profile[1:] * pump_power[1:] * timesteps / eff)
 
             constraints.append(((variable_operational_cost - sum_) / nominal, 0.0, 0.0))
 
@@ -991,7 +991,7 @@ class FinancialMixin(
 
             price_profile = self.__get_electricity_price_profile_or_zero()
 
-            sum_ = ca.sum1(price_profile.values[1:] * pump_power[1:] * timesteps_hr / eff)
+            sum_ = ca.sum1(price_profile[1:] * pump_power[1:] * timesteps_hr / eff)
 
             constraints.append(((variable_operational_cost - sum_) / nominal, 0.0, 0.0))
 
@@ -1042,7 +1042,7 @@ class FinancialMixin(
                 ca.sum1(variable_operational_cost_coefficient * nominator_vector[1:] * timesteps_hr)
                 / denominator
             )
-            sum_ += ca.sum1(price_profile.values[1:] * pump_power[1:] * timesteps_hr / eff)
+            sum_ += ca.sum1(price_profile[1:] * pump_power[1:] * timesteps_hr / eff)
 
             if (len(self.get_electricity_carriers().keys()) > 0) and s in [
                 *self.energy_system_components.get("heat_source_elec", []),
@@ -1051,8 +1051,7 @@ class FinancialMixin(
                 *self.energy_system_components.get("heat_pump_elec", []),
             ]:
                 sum_ += (
-                    ca.sum1(price_profile.values[1:] * nominator_vector[1:] * timesteps_hr)
-                    / denominator
+                    ca.sum1(price_profile[1:] * nominator_vector[1:] * timesteps_hr) / denominator
                 )
                 if variable_operational_cost_coefficient > 0.0:
                     logger.warning(
@@ -1082,11 +1081,11 @@ class FinancialMixin(
             sum_ = ca.sum1(
                 variable_operational_cost_coefficient * elec_consumption[1:] * timesteps_hr
             )
-            sum_ += ca.sum1(price_profile.values[1:] * pump_power[1:] * timesteps_hr / eff)
+            sum_ += ca.sum1(price_profile[1:] * pump_power[1:] * timesteps_hr / eff)
             if hp not in self.energy_system_components.get("heat_pump_elec", []):
                 # assuming that if heatpump has electricity port, the cost for the electricity
                 # are already made by the electricity producer and transport
-                sum_ += ca.sum1(price_profile.values[1:] * elec_consumption[1:] * timesteps_hr)
+                sum_ += ca.sum1(price_profile[1:] * elec_consumption[1:] * timesteps_hr)
             constraints.append(((variable_operational_cost - sum_) / nominal, 0.0, 0.0))
 
         for ac in self.energy_system_components.get("airco", []):

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -798,7 +798,7 @@ class FinancialMixin(
         assert len(electricity_carriers.keys()) <= 1
 
         if len(electricity_carriers.keys()) == 0:
-            return Timeseries(self.times(), np.zeros(len(self.times())))
+            return np.zeros(len(self.times()))
 
         price_profile_name = f"{list(electricity_carriers.values())[0]['name']}.price_profile"
         if price_profile_name in self.io.get_timeseries_names():

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -805,7 +805,7 @@ class FinancialMixin(
             price_profile_timeseries = self.get_timeseries(price_profile_name)
             # The slicing is required if the timeseries wasn't adapted in the read
             mask = (price_profile_timeseries.times >= self.times()[0]) & (
-                    price_profile_timeseries.times <= self.times()[-1]
+                price_profile_timeseries.times <= self.times()[-1]
             )
             price_profile = price_profile_timeseries.values[mask]
             return price_profile

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -802,7 +802,13 @@ class FinancialMixin(
 
         price_profile_name = f"{list(electricity_carriers.values())[0]['name']}.price_profile"
         if price_profile_name in self.io.get_timeseries_names():
-            return self.get_timeseries(price_profile_name)
+            price_profile_timeseries = self.get_timeseries(price_profile_name)
+            # The slicing is required if the timeseries wasn't adapted in the read
+            mask = (price_profile_timeseries.times >= self.times()[0]) & (
+                    price_profile_timeseries.times <= self.times()[-1]
+            )
+            price_profile = price_profile_timeseries.values[mask]
+            return price_profile
 
         return Timeseries(self.times(), np.zeros(len(self.times())))
 


### PR DESCRIPTION
Adapted some electricity related timeseries such that slicing is used properly for electricity related input timeseries.

ToDo:

- [ ] Changelog