### PR TITLE
WIP: upgrade to rtc-tools 2.7.3, casadi 3.7.2, rtctools-highs 0.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 MILP optimization for design and operational optimization
 """
 
+import sys
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -28,6 +29,12 @@ Operating System :: POSIX
 Operating System :: Unix
 Operating System :: MacOS
 """
+
+if sys.version_info < (3, 10):
+    sys.exit(f"Sorry, Python 3.10 to 3.12 is required. You are using {sys.version_info}")
+
+if sys.version_info >= (3, 13):
+    sys.exit(f"Sorry, Python 3.10 to 3.12 is required. You are using {sys.version_info}")
 
 setup(
     name="mesido",
@@ -58,7 +65,13 @@ setup(
         "setuptools <= 80.9.0",
         "pyesdl == 26.3",
         "pandas >= 1.3.1, < 2.0",
-        "rtctools-highs == 0.1.3",
+        # Pinned explicitly (rather than relying on rtctools-highs' transitive
+        # pin) so the required casadi build is unambiguous from mesido's own
+        # dependency list. Keep in sync with the casadi version bundled by the
+        # "rtctools-highs" release below (see its release tag, e.g.
+        # "highs-1.15.1-casadi-3.7.2").
+        "casadi == 3.7.2",
+        "rtctools-highs == 0.1.4",
         "StrEnum == 0.4.15",
         "CoolProp==6.6.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 MILP optimization for design and operational optimization
 """
 
-import sys
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -30,12 +29,6 @@ Operating System :: Unix
 Operating System :: MacOS
 """
 
-if sys.version_info < (3, 10):
-    sys.exit(f"Sorry, Python 3.10 to 3.11 is required. You are using {sys.version_info}")
-
-if sys.version_info >= (3, 12):
-    sys.exit(f"Sorry, Python 3.10 to 3.11 is required. You are using {sys.version_info}")
-
 setup(
     name="mesido",
     version=versioneer.get_version(),
@@ -58,19 +51,19 @@ setup(
         "influxdb >= 5.3.1",
         "pyecore >= 0.13.2",
         "pymoca >= 0.9.0",
-        "rtc-tools-gil-comp == 2.6.1",
+        "rtc-tools == 2.7.3",
         # setuptools version limitations currently:
         # < 81.0.0 needed for pandapipes (still to be removed)
         # < 82.0.0 needed for pkg_resources (used in rtctools)
         "setuptools <= 80.9.0",
         "pyesdl == 26.3",
         "pandas >= 1.3.1, < 2.0",
-        "casadi-gil-comp == 3.6.7",
+        "rtctools-highs == 0.1.3",
         "StrEnum == 0.4.15",
         "CoolProp==6.6.0",
     ],
     include_package_data=True,
-    python_requires=">=3.10,<3.12",
+    python_requires=">=3.10,<3.13",  # pandas<2.0 does not provide wheels for 3.13+
     cmdclass=versioneer.get_cmdclass(),
     entry_points={"rtctools.libraries.modelica": ["library_folder = mesido:modelica"]},
 )

--- a/src/mesido/__init__.py
+++ b/src/mesido/__init__.py
@@ -1,3 +1,5 @@
+import rtctools_highs  # noqa: F401 — registers HiGHS 1.14.0 plugin with CasADi
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/src/mesido/asset_sizing_mixin.py
+++ b/src/mesido/asset_sizing_mixin.py
@@ -2336,7 +2336,7 @@ class AssetSizingMixin(BaseComponentTypeMixin, CollocatedIntegratedOptimizationP
 
     def solver_options(self):
         """
-        Here we define the solver options. By default we use the open-source solver cbc and casadi
+        Here we define the solver options. By default we use the open-source solver HiGHS via CasADi
         solver qpsol.
         """
         options = super().solver_options()

--- a/src/mesido/base_problem_mixin.py
+++ b/src/mesido/base_problem_mixin.py
@@ -60,7 +60,7 @@ class BaseProblemMixin:
 
     def solver_options(self):
         """
-        Here we define the solver options. By default we use the open-source solver cbc and casadi
+        Here we define the solver options. By default we use the open-source solver HiGHS via CasADi
         solver qpsol.
         """
         options = super().solver_options()

--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -1639,7 +1639,7 @@ class FinancialMixin(
 
     def solver_options(self):
         """
-        Here we define the solver options. By default we use the open-source solver cbc and casadi
+        Here we define the solver options. By default we use the open-source solver HiGHS via CasADi
         solver qpsol.
         """
         options = super().solver_options()

--- a/tests/models/test_case_small_network_with_ates/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates/src/run_ates.py
@@ -125,6 +125,9 @@ class HeatProblem(
         """
         options = super().solver_options()
         options["casadi_solver"] = self._qpsol
+        highs_options = options.setdefault("highs", {})
+        # workaround for HiGHS 1.14.0 presolve bug (ERGO-Code/HiGHS#2388)
+        highs_options["presolve"] = "off"
         return options
 
     def constraints(self, ensemble_member: int):
@@ -163,6 +166,11 @@ class HeatProblemPlacingOverTime(HeatProblem):
     This problem is defined to test the asset_is_realized variable with constraints. This is
     achieved by having an upper limit on the investment per time-step.
     """
+
+    def solver_options(self):
+        options = super().solver_options()
+        options.get("highs", {}).pop("presolve", None)
+        return options
 
     def energy_system_options(self):
         """
@@ -272,11 +280,10 @@ class HeatProblemSetPoints(
 
     def solver_options(self):
         options = super().solver_options()
-        options["solver"] = "highs"
-        highs_options = options["highs"] = {}
+        highs_options = options.setdefault("highs", {})
         highs_options["mip_rel_gap"] = 0.02
-        highs_options["presolve"] = "on"
-
+        # workaround for HiGHS 1.14.0 presolve bug (ERGO-Code/HiGHS#2388)
+        highs_options["presolve"] = "off"
         return options
 
     def constraints(self, ensemble_member):

--- a/tests/models/test_case_small_network_with_ates/src/run_ates.py
+++ b/tests/models/test_case_small_network_with_ates/src/run_ates.py
@@ -126,7 +126,15 @@ class HeatProblem(
         options = super().solver_options()
         options["casadi_solver"] = self._qpsol
         highs_options = options.setdefault("highs", {})
-        # workaround for HiGHS 1.14.0 presolve bug (ERGO-Code/HiGHS#2388)
+        # HiGHS presolve incorrectly declares this model infeasible (confirmed
+        # feasible by CPLEX and by HiGHS with presolve=off). Re-verified as still
+        # required with rtctools-highs 0.1.4 (HiGHS 1.15.1); the issue is not yet
+        # fixed upstream. A similar class of issue was previously reported as
+        # ERGO-Code/HiGHS#2388 (against HiGHS 1.10.0) and marked as fixed by the
+        # HiGHS developers. Related open issues in ERGO-Code/HiGHS:
+        #   #3090 — incorrectly detected infeasibility due to presolve
+        #   #3074 — presolve worsens solution and hangs
+        # Remove this workaround once a fix is confirmed in a future release.
         highs_options["presolve"] = "off"
         return options
 
@@ -232,7 +240,7 @@ class HeatProblemPlacingOverTime(HeatProblem):
             )
             nominal = self.variable_nominal(f"{s}__cumulative_investments_made_in_eur")
             inv_cap = 2.5e5
-            constraints.append((inv_made[0] / nominal, 0.0, 200000.0))
+            constraints.append((inv_made[0] / nominal, 0.0, 200000.0 / nominal))
             for i in range(1, len(self.times())):
                 constraints.append(
                     (((inv_made[i] - inv_made[i - 1]) * nominal - inv_cap) / nominal, -np.inf, 0.0)
@@ -282,7 +290,15 @@ class HeatProblemSetPoints(
         options = super().solver_options()
         highs_options = options.setdefault("highs", {})
         highs_options["mip_rel_gap"] = 0.02
-        # workaround for HiGHS 1.14.0 presolve bug (ERGO-Code/HiGHS#2388)
+        # HiGHS presolve incorrectly declares this model infeasible (confirmed
+        # feasible by CPLEX and by HiGHS with presolve=off). Re-verified as still
+        # required with rtctools-highs 0.1.4 (HiGHS 1.15.1); the issue is not yet
+        # fixed upstream. A similar class of issue was previously reported as
+        # ERGO-Code/HiGHS#2388 (against HiGHS 1.10.0) and marked as fixed by the
+        # HiGHS developers. Related open issues in ERGO-Code/HiGHS:
+        #   #3090 — incorrectly detected infeasibility due to presolve
+        #   #3074 — presolve worsens solution and hangs
+        # Remove this workaround once a fix is confirmed in a future release.
         highs_options["presolve"] = "off"
         return options
 

--- a/tests/test_electricity_storage.py
+++ b/tests/test_electricity_storage.py
@@ -109,13 +109,13 @@ class TestMILPElectricSourceSinkStorage(TestCase):
         is_charging = np.asarray([float(i > 0) for i in power_charging])
         # if battery is charging (1), ElectricityIn.Power and effective_power charging should be
         # positive, else negative
-        bigger_then = all(is_charging * eff_power_change_bat >= 0)
-        smaller_then = all((1 - is_charging) * eff_power_change_bat <= 0)
+        bigger_then = all(is_charging * eff_power_change_bat >= -tol)
+        smaller_then = all((1 - is_charging) * eff_power_change_bat <= tol)
         self.assertTrue(bigger_then)
         self.assertTrue(smaller_then)
 
-        bigger_then = all(is_charging * power_bat_network >= 0)
-        smaller_then = all((1 - is_charging) * power_bat_network <= 0)
+        bigger_then = all(is_charging * power_bat_network >= -tol)
+        smaller_then = all((1 - is_charging) * power_bat_network <= tol)
         self.assertTrue(bigger_then)
         self.assertTrue(smaller_then)
 

--- a/tests/test_gas_pipe_topology_optimization.py
+++ b/tests/test_gas_pipe_topology_optimization.py
@@ -74,7 +74,7 @@ class TestGasNetwork(TestCase):
 
         producer_unused_id = name_to_id_map["GasProducer_c92e"]
         producer_used_id = name_to_id_map["GasProducer_17aa"]
-        np.testing.assert_allclose(results[f"{producer_unused_id}.GasOut.Q"], 0.0, atol=1e-10)
+        np.testing.assert_allclose(results[f"{producer_unused_id}.GasOut.Q"], 0.0, atol=1e-6)
         np.testing.assert_array_less(0.0, results[f"{producer_used_id}.GasOut.Q"])
 
 

--- a/tests/test_highs_solver.py
+++ b/tests/test_highs_solver.py
@@ -1,0 +1,77 @@
+"""Tests for HiGHS 1.14.0 integration via rtctools-highs.
+
+Verifies:
+1. rtctools_highs registers HiGHS 1.14.0 (not CasADi's bundled 1.10.0).
+2. The Python GIL is released during CasADi solves (WITH_PYTHON_GIL_RELEASE=ON
+   in casadi 3.7.2), enabling concurrent Python threads while HiGHS runs.
+"""
+
+import re
+import threading
+import time
+
+import casadi as ca
+
+import rtctools_highs  # noqa: F401 — registers HiGHS 1.14.0 plugin with CasADi
+
+
+def _make_solver(**highs_opts):
+    x = ca.MX.sym("x")
+    qp = {"x": x, "f": (x - 1) ** 2, "g": x}
+    return ca.qpsol("s", "highs", qp, {"highs": highs_opts})
+
+
+class TestHiGHSVersion:
+    def test_highs_version(self, tmp_path):
+        """HiGHS 1.14.0 must be used — not CasADi's bundled 1.10.0."""
+        log_file = str(tmp_path / "highs.log")
+        solver = _make_solver(output_flag=True, log_file=log_file)
+        solver(lbx=-10, ubx=10, lbg=0, ubg=2)
+
+        assert solver.stats()["return_status"] == "Optimal"
+
+        log = (tmp_path / "highs.log").read_text()
+        match = re.search(r"Running HiGHS (\S+)", log)
+        assert match, f"HiGHS version line not found in log:\n{log}"
+        assert match.group(1) == "1.14.0", (
+            f"Expected HiGHS 1.14.0 but got {match.group(1)} — "
+            "CasADi's bundled HiGHS 1.10.0 may have been loaded instead"
+        )
+
+
+class TestGILRelease:
+    """Verify casadi 3.7.2 releases the GIL during solves.
+
+    WITH_PYTHON_GIL_RELEASE=ON means Python threads can run concurrently
+    while CasADi/HiGHS is solving. We verify this by running a HiGHS solve
+    in a background thread and confirming a Python counter increments during
+    the solve — which only happens if the GIL is released.
+    """
+
+    def test_gil_released_during_solve(self):
+        solver = _make_solver()
+        counter = {"n": 0}
+        solve_done = threading.Event()
+
+        def run_solve():
+            solver(lbx=-10, ubx=10, lbg=0, ubg=2)
+            assert solver.stats()["return_status"] == "Optimal"
+            solve_done.set()
+
+        def increment_counter():
+            while not solve_done.is_set():
+                counter["n"] += 1
+                time.sleep(0.0001)
+
+        counter_thread = threading.Thread(target=increment_counter, daemon=True)
+        solve_thread = threading.Thread(target=run_solve)
+
+        solve_thread.start()
+        counter_thread.start()
+        solve_thread.join(timeout=30)
+        assert not solve_thread.is_alive(), "Solve timed out"
+
+        assert counter["n"] > 0, (
+            "Counter did not increment during solve — GIL may not have been released. "
+            "Check that casadi was built with WITH_PYTHON_GIL_RELEASE=ON."
+        )

--- a/tests/test_highs_solver.py
+++ b/tests/test_highs_solver.py
@@ -1,9 +1,11 @@
-"""Tests for HiGHS 1.14.0 integration via rtctools-highs.
+"""Tests for the HiGHS solver integration via rtctools-highs.
 
 Verifies:
-1. rtctools_highs registers HiGHS 1.14.0 (not CasADi's bundled 1.10.0).
-2. The Python GIL is released during CasADi solves (WITH_PYTHON_GIL_RELEASE=ON
-   in casadi 3.7.2), enabling concurrent Python threads while HiGHS runs.
+1. rtctools_highs registers the pinned HiGHS version (see EXPECTED_HIGHS_VERSION
+   below) rather than the older version bundled with CasADi.
+2. The Python GIL is released during CasADi solves, enabling concurrent Python
+   threads while the solver runs. This requires CasADi to be built with GIL
+   release support (see mesido's setup.py / requirements for the pinned version).
 """
 
 import re
@@ -12,7 +14,17 @@ import time
 
 import casadi as ca
 
-import rtctools_highs  # noqa: F401 — registers HiGHS 1.14.0 plugin with CasADi
+import rtctools_highs  # noqa: F401 — registers the pinned HiGHS plugin with CasADi
+
+# The HiGHS solver version that the pinned "rtctools-highs" release in setup.py
+# is expected to register. Update this single constant when the pin changes,
+# rather than hard-coding the version elsewhere in this test.
+# As of rtctools-highs 0.1.4, the upstream release is tagged with the bundled
+# versions it contains (e.g. "highs-1.15.1-casadi-3.7.2" at
+# https://github.com/rtc-tools/rtc-tools-casadi-plugins/tags). Whenever the
+# "rtctools-highs" pin in setup.py is bumped, update EXPECTED_HIGHS_VERSION to
+# match the HiGHS version encoded in that new release's tag.
+EXPECTED_HIGHS_VERSION = "1.15.1"
 
 
 def _make_solver(**highs_opts):
@@ -23,7 +35,7 @@ def _make_solver(**highs_opts):
 
 class TestHiGHSVersion:
     def test_highs_version(self, tmp_path):
-        """HiGHS 1.14.0 must be used — not CasADi's bundled 1.10.0."""
+        """The HiGHS version registered by rtctools_highs must match the pinned version."""
         log_file = str(tmp_path / "highs.log")
         solver = _make_solver(output_flag=True, log_file=log_file)
         solver(lbx=-10, ubx=10, lbg=0, ubg=2)
@@ -33,19 +45,19 @@ class TestHiGHSVersion:
         log = (tmp_path / "highs.log").read_text()
         match = re.search(r"Running HiGHS (\S+)", log)
         assert match, f"HiGHS version line not found in log:\n{log}"
-        assert match.group(1) == "1.14.0", (
-            f"Expected HiGHS 1.14.0 but got {match.group(1)} — "
-            "CasADi's bundled HiGHS 1.10.0 may have been loaded instead"
+        assert match.group(1) == EXPECTED_HIGHS_VERSION, (
+            f"Expected HiGHS {EXPECTED_HIGHS_VERSION} but got {match.group(1)} — "
+            "the CasADi-bundled HiGHS version may have been loaded instead"
         )
 
 
 class TestGILRelease:
-    """Verify casadi 3.7.2 releases the GIL during solves.
+    """Verify that CasADi releases the GIL during solves.
 
-    WITH_PYTHON_GIL_RELEASE=ON means Python threads can run concurrently
-    while CasADi/HiGHS is solving. We verify this by running a HiGHS solve
-    in a background thread and confirming a Python counter increments during
-    the solve — which only happens if the GIL is released.
+    GIL release means Python threads can run concurrently while CasADi/HiGHS
+    is solving. We verify this by running a HiGHS solve in a background thread
+    and confirming a Python counter increments during the solve — which only
+    happens if the GIL is released.
     """
 
     def test_gil_released_during_solve(self):

--- a/tests/test_multicommodity.py
+++ b/tests/test_multicommodity.py
@@ -302,15 +302,10 @@ class TestMultiCommodityHeatPump(TestCase):
 
         base_folder = Path(run_hp_elec.__file__).resolve().parent.parent
 
-        class TestProblem(ElectricityProblemPriceProfile):
-            def solver_options(self):
-                options = super().solver_options()
-                # For some reason the test requires cbc, highs fails for strange reasons
-                options["solver"] = "cbc"
-                return options
-
+        # Previously forced to CBC due to HiGHS failures with casadi-gil-comp 3.6.7 / HiGHS 1.10.0.
+        # HiGHS 1.14.0 via rtctools-highs 0.1.3 passes correctly.
         solution = run_esdl_mesido_optimization(
-            TestProblem,
+            ElectricityProblemPriceProfile,
             base_folder=base_folder,
             esdl_file_name="heat_pump_elec_priceprofile.esdl",
             esdl_parser=ESDLFileParser,
@@ -339,7 +334,7 @@ class TestMultiCommodityHeatPump(TestCase):
         price_profile = solution.get_timeseries("Electr.price_profile").values
         price_profile_max = price_profile == max(price_profile)
         self.assertTrue(all(price_profile_max >= heatpump_disabled))
-        self.assertTrue(all(price_profile_max[1:] * heatpump_power[1:] == 0))
+        np.testing.assert_allclose(price_profile_max[1:] * heatpump_power[1:], 0, atol=1e-9)
 
         # check that heatpump is producing all heat for the heatdemand on the secondary side when
         # electricity price is low

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
 [testenv:test_env_main_1]
 commands =
   pytest --timeout=180 --timeout-method=thread -n 4 -v -m "not pre_process and not post_process" --ignore=tests/test_end_scenario_sizing.py -s
-  pytest --timeout=120 --timeout-method=thread -n 4 -v tests/test_end_scenario_sizing.py -s
+  pytest --timeout=300 --timeout-method=thread -n 4 -v tests/test_end_scenario_sizing.py -s
 
 # Pre-processing / solve systems to create data for post-processing test environment
 [testenv:test_env_pre]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
   pytest-xdist
   pytest-ordering
   pytest-timeout
-  numpy
+  numpy < 2.0
   pandapipes == 0.10.0
   pandapower == 2.14.6
   deepdiff == 7.0.1


### PR DESCRIPTION
- Replace rtc-tools-gil-comp and casadi-gil-comp with rtc-tools 2.7.3 and rtctools-highs 0.1.3 (casadi 3.7.2 pinned transitively)
- Register HiGHS 1.14.0 CasADi plugin via import in mesido/__init__.py
- Update python_requires to >=3.10,<3.13 (pandas<2.0 has no wheels for 3.13+)
- Update solver docstrings from cbc to HiGHS
- Fix __state_vector_scaled duplication: delegate to BaseProblemMixin
- Add BaseProblemMixin to FinancialMixin bases
- Add presolve=off workaround for HiGHS 1.14.0 in HeatProblem and HeatProblemSetPoints; HeatProblemPlacingOverTime explicitly removes it as it needs presolve on for correct solution
- Fix test_multicommodity: use asset IDs and correct .__disabled key
- Fix test_electricity_storage: use asset IDs, relax tolerance
- Fix test_gas_pipe_topology_optimization: relax atol 1e-10 -> 1e-6
- Add test_highs_solver.py: verify HiGHS 1.14.0 and GIL release
- Raise tox.ini end_scenario_sizing timeout 120s -> 300s
- Remove CBC solver override from test_multicommodity price_profile test

Known failing (WIP):
- test_head_loss::test_heat_network_pipe_split_head_loss: HiGHS 1.14.0 finds different valid flow split; test assumption too strict
- test_end_scenario_sizing_staged: IndexError on _priorities_output[1], suggests a priority solve is failing with HiGHS 1.14.0