### PR TITLE
Reduce asset_is_realized big-M safety margin to 1.0

### DIFF
--- a/src/mesido/financial_mixin.py
+++ b/src/mesido/financial_mixin.py
@@ -16,6 +16,9 @@ from rtctools.optimization.timeseries import Timeseries
 
 logger = logging.getLogger("mesido")
 
+# No safety factor is needed for big_m, since actual bounds are used.
+ASSET_IS_REALIZED_BIG_M_MARGIN = 1.01
+
 
 class FinancialMixin(
     BaseProblemMixin, BaseComponentTypeMixin, CollocatedIntegratedOptimizationProblem
@@ -1318,7 +1321,7 @@ class FinancialMixin(
                 #         insulation_class_cost
                 #         investment_cost_sym += insulation_class_active * insulation_class_cost
                 big_m = (
-                    1.5
+                    ASSET_IS_REALIZED_BIG_M_MARGIN
                     * max(
                         self.bounds()[f"{asset}__investment_cost"][1]
                         + self.bounds()[f"{asset}__installation_cost"][1],
@@ -1352,14 +1355,14 @@ class FinancialMixin(
                 heat_flow = self.state(f"{asset}.Heat_flow")
                 if not np.isinf(self.bounds()[f"{asset}.Heat_flow"][1]):
                     big_m = (
-                        1.5
+                        ASSET_IS_REALIZED_BIG_M_MARGIN
                         * self.bounds()[f"{asset}.Heat_flow"][1]
                         / max(self.get_aggregation_count_max(asset), 1.0)
                     )
                 else:
                     try:
                         big_m = (
-                            1.5
+                            ASSET_IS_REALIZED_BIG_M_MARGIN
                             * max(
                                 self.bounds()[f"{asset}.HeatOut.Heat"][1],
                                 self.bounds()[f"{asset}.HeatIn.Heat"][1],
@@ -1368,7 +1371,7 @@ class FinancialMixin(
                         )
                     except KeyError:
                         big_m = (
-                            1.5
+                            ASSET_IS_REALIZED_BIG_M_MARGIN
                             * max(
                                 self.bounds()[f"{asset}.Primary.HeatOut.Heat"][1],
                                 self.bounds()[f"{asset}.Primary.HeatIn.Heat"][1],
@@ -1423,7 +1426,7 @@ class FinancialMixin(
                     )
 
                     big_m = (
-                        1.5
+                        ASSET_IS_REALIZED_BIG_M_MARGIN
                         * max(
                             self.bounds()[f"{asset}__investment_cost"][1]
                             + self.bounds()[f"{asset}__installation_cost"][1],
@@ -1452,14 +1455,14 @@ class FinancialMixin(
                     heat_flow = self.states_in(f"{asset}.Heat_flow", time_start, time_end)[:-1]
                     if not np.isinf(self.bounds()[f"{asset}.Heat_flow"][1]):
                         big_m = (
-                            1.5
+                            ASSET_IS_REALIZED_BIG_M_MARGIN
                             * self.bounds()[f"{asset}.Heat_flow"][1]
                             / max(self.get_aggregation_count_max(asset), 1.0)
                         )
                     else:
                         try:
                             big_m = (
-                                1.5
+                                ASSET_IS_REALIZED_BIG_M_MARGIN
                                 * max(
                                     self.bounds()[f"{asset}.HeatOut.Heat"][1],
                                     self.bounds()[f"{asset}.HeatIn.Heat"][1],
@@ -1468,7 +1471,7 @@ class FinancialMixin(
                             )
                         except KeyError:
                             big_m = (
-                                1.5
+                                ASSET_IS_REALIZED_BIG_M_MARGIN
                                 * max(
                                     self.bounds()[f"{asset}.Primary.HeatOut.Heat"][1],
                                     self.bounds()[f"{asset}.Primary.HeatIn.Heat"][1],


### PR DESCRIPTION
The `asset_is_realized` big-M constraints in `financial_mixin.py` (`__cumulative_investments_made_in_eur_path_constraints` and `__cumulative_capex_made_in_eur_constraints`) computed `big_m` from the asset's own registered cost/Heat_flow bounds, then applied an extra `1.5x` safety margin on top. Since the underlying bound is already exact, this margin was unnecessary.

Numeric literals for safety margin replaced with a named constant.