### PR TITLE
Fix for minimum velocity for staged endscenariosizing and zero heat demand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Fixed
 - Bug: Only update the aggregation count for an ATES and a GeothermalSource in DTK post processing
+- Bug: minimum velocity is set to 0.0 in the staged grow_workflow to allow for zero heat demand.
 
 # [0.1.20] - 2026-06-15
 

--- a/manual_run/testing_bugs/src/run_grow.py
+++ b/manual_run/testing_bugs/src/run_grow.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     solution = run_end_scenario_sizing(
         EndScenarioSizingStaged,
         base_folder=base_folder,
-        esdl_file_name="Base Netwerk Delft.esdl",
+        esdl_file_name="OMOTES_test_0729.esdl",
         esdl_parser=ESDLFileParser,
         # **kwargs,  # Example of usage if needed/used
     )

--- a/manual_run/testing_bugs/src/run_grow.py
+++ b/manual_run/testing_bugs/src/run_grow.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     solution = run_end_scenario_sizing(
         EndScenarioSizingStaged,
         base_folder=base_folder,
-        esdl_file_name="OMOTES_test_0729.esdl",
+        esdl_file_name="Base Netwerk Delft.esdl",
         esdl_parser=ESDLFileParser,
         # **kwargs,  # Example of usage if needed/used
     )

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -604,7 +604,15 @@ class EndScenarioSizing(
                 solver_stats = self.solver_stats
                 self._write_json_output(results, parameters, bounds, aliases, solver_stats, e_m)
 
-    def __heat_demand_match_check(self, results, e_m=0):
+    def __heat_demand_match_check(self, results: AliasDict, e_m: int = 0) -> None:
+        """
+        Checks if the heat demand is not matched and provides potential causes in the
+        logger.
+
+        Args:
+            results: Alias dictionary of the results after the optimization
+            e_m: Ensemble member index
+        """
         parameters = self.parameters(e_m)
         bounds = self.bounds()
         id_to_name_map = self.esdl_asset_id_to_name_map
@@ -767,13 +775,14 @@ class SettingsStaged:
         *args,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
 
         self._stage = stage
         self._total_stages = total_stages
         self.__boolean_bounds = boolean_bounds
         if self._stage == 2 and priorities_output:
             self._priorities_output = priorities_output
+
+        super().__init__(*args, **kwargs)
 
     def update_heat_network_settings(self):
         settings = super().update_heat_network_settings()
@@ -794,10 +803,11 @@ class SettingsStaged:
         elif self._stage == 2:
             # If at least 1 heat_source has a producer profile assigned, set the
             # heat_loss_disconnected_pipe option to False
-            for asset in self.energy_system_components.get("heat_source", []):
-                if f"{asset}.maximum_heat_source" in self.io.get_timeseries_names():
-                    options["heat_loss_disconnected_pipe"] = False
-                    break
+            if hasattr(self, "_ModelicaComponentTypeMixin__hn_component_types"):
+                for asset in self.energy_system_components.get("heat_source", []):
+                    if f"{asset}.maximum_heat_source" in self.io.get_timeseries_names():
+                        options["heat_loss_disconnected_pipe"] = False
+                        break
 
         return options
 

--- a/tests/test_end_scenario_sizing.py
+++ b/tests/test_end_scenario_sizing.py
@@ -19,7 +19,12 @@ import numpy as np
 
 from rtctools.util import run_optimization_problem
 
-from utils_tests import cost_calculation_test, demand_matching_test
+from utils_tests import (
+    cost_calculation_test,
+    demand_matching_test,
+    energy_conservation_test,
+    heat_to_discharge_test,
+)
 
 
 class TestEndScenarioSizing(TestCase):
@@ -42,6 +47,38 @@ class TestEndScenarioSizing(TestCase):
         )
         cls.results = cls.solution.extract_results()
         cls.name_to_id_map = cls.solution.esdl_asset_name_to_id_map
+
+    def test_end_scenario_sizing_no_demand(self):
+        """
+        Checks if EndScenarioSizing also works for ESDLs where the heat demand is zero at some
+        moments in time.
+        This run will fail when the minimum velocity is not set equal to zero.
+
+        Checks:
+        - demand matching
+        - heat to discharge
+        - energy conservation
+        """
+
+        import models.source_pipe_sink.src.double_pipe_heat as double_pipe_heat
+
+        base_folder = Path(double_pipe_heat.__file__).resolve().parent.parent
+
+        solution = run_end_scenario_sizing(
+            EndScenarioSizingStaged,
+            base_folder=base_folder,
+            esdl_file_name="sourcesink.esdl",
+            esdl_parser=ESDLFileParser,
+            profile_reader=ProfileReaderFromFile,
+            input_timeseries_file="timeseries_import_zero_demand.csv",
+        )
+        results = solution.extract_results()
+
+        demand_matching_test(solution, results)
+        heat_to_discharge_test(solution, results)
+        energy_conservation_test(solution, results)
+
+        np.testing.assert_allclose(solution.heat_network_settings["minimum_velocity"], 0.0)
 
     def test_end_scenario_sizing(self):
         """


### PR DESCRIPTION
To allow zero heat demand at some time instances, the minimum velocity has to be set to 0.0. In EndScenarioSizingStaged, this was happening in the wrong order.