### PR TITLE
267 buffer tank value at t0

### DIFF
--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import time
+from cmath import nan
 from typing import Dict
 
 from mesido.esdl.esdl_additional_vars_mixin import ESDLAdditionalVarsMixin
@@ -336,6 +337,8 @@ class EndScenarioSizing(
         parameters["peak_day_index"] = self.__indx_max_peak
         parameters["time_step_days"] = self.__day_steps
         parameters["number_of_years"] = self._number_of_years
+        for b in self.energy_system_components.get("heat_buffer", []):
+            parameters[f"{b}.init_Heat"] = nan
         return parameters
 
     def pre(self):
@@ -433,7 +436,8 @@ class EndScenarioSizing(
         for b in self.energy_system_components.get("heat_buffer", {}):
             vars = self.state_vector(f"{b}.Heat_buffer")
             symbol_stored_heat = self.state_vector(f"{b}.Stored_heat")
-            constraints.append((symbol_stored_heat[self.__indx_max_peak], 0.0, 0.0))
+            constraints.append((symbol_stored_heat[self.__indx_max_peak]-symbol_stored_heat[
+                self.__indx_max_peak+24], 0.0, 0.0))
 
             ind_peak = int(self.__indx_max_peak)
             constraints.append((vars[:ind_peak], 0.0, 0.0))

--- a/src/mesido/workflows/grow_workflow.py
+++ b/src/mesido/workflows/grow_workflow.py
@@ -436,8 +436,14 @@ class EndScenarioSizing(
         for b in self.energy_system_components.get("heat_buffer", {}):
             vars = self.state_vector(f"{b}.Heat_buffer")
             symbol_stored_heat = self.state_vector(f"{b}.Stored_heat")
-            constraints.append((symbol_stored_heat[self.__indx_max_peak]-symbol_stored_heat[
-                self.__indx_max_peak+24], 0.0, 0.0))
+            constraints.append(
+                (
+                    symbol_stored_heat[self.__indx_max_peak]
+                    - symbol_stored_heat[self.__indx_max_peak + 24],
+                    0.0,
+                    0.0,
+                )
+            )
 
             ind_peak = int(self.__indx_max_peak)
             constraints.append((vars[:ind_peak], 0.0, 0.0))


### PR DESCRIPTION
The initial heat buffer stored heat variable is set to the minimum value by default. In workflows this can be updated int he parameters. If can be set to 'nan' in case no initial value is needed.

For the grow workflow this has now been set to nan, as the peak day could appear the first timestep and for the buffer we assume a cyclic constraint for the stored heat within a day.

todo:

- [ ] update changelog